### PR TITLE
add: Option to suppress checksum validation of incoming data from ve.direct data-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ module.exports = function (app) {
         type: 'string',
         title: 'Solar name in SK path',
         default: 'Main'
+      },
+      ignoreChecksum: {
+        type: 'boolean',
+        title: 'Ignore Checksum and suppress corresponding log',
+        default: false
       }
     }
   }

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -105,13 +105,21 @@ class VEDirectParser extends EventEmitter {
     let converted = null
 
     if (!Array.isArray(this.line) || this.line.length !== 2) {
-      return this.warn('_parse() called on invalid line: ' + JSON.stringify({ line: this.line }))
+      if (this.options.ignoreChecksum !== true) {
+         return this.warn('_parse() called on invalid line: ' + JSON.stringify({ line: this.line }))
+      }else{
+         return
+      }
     }
 
     field = String(this.line[0]).toUpperCase()
 
     if (!Object.keys(this.fields).includes(field) || typeof this.fields[field] !== 'object' || this.fields[field] === null) {
-      return this.warn(`No field definition for: ${field}, ignoring`)
+      if (this.options.ignoreChecksum !== true) {
+         return this.warn(`No field definition for: ${field}, ignoring`)
+      }else{
+         return
+      }
     }
 
     field = this.fields[field]


### PR DESCRIPTION
Option to suppress checksum validation of incoming data from ve.direct data-stream. This allows to read incoming data from battery chargers of the Phoenix Smart IP43 family and leads to a clean, uninterrupted data stream of voltages and current. This mofification was tested for about half a year. This feature was actually already implemented but a corresponding checkbox was missing in the user interface. Additionally now logging checksum errors to syslog is suppressed as well.