### PR TITLE
fixed SerialPort buffering

### DIFF
--- a/lib/serial.js
+++ b/lib/serial.js
@@ -1,4 +1,5 @@
 const SerialPort = require('serialport')
+const Delimiter = require('@serialport/parser-delimiter')
 const debug = require('debug')('signalk-vedirect-parser')
 let port = null
 
@@ -12,7 +13,9 @@ exports.open = function openSerialConnection (device, parser) {
 
   port = new SerialPort(device, { baudRate: 19200 }) // @NOTE FT: should this be configurable?
 
-  port.on('data', chunk => {
+  const delim = port.pipe(new Delimiter({delimiter: '\r' , includeDelimiter: true}))
+
+  delim.on('data', chunk => {
     // Chunk is a node.js Buffer
     parser.addChunk(chunk)
   })


### PR DESCRIPTION
introduced Delimiter parser between port and parser, so the buffered input gets handed off to the parser on every carriage return (beginning of VE.direct data frame)