### PR TITLE
Add BMV to fields.js

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -442,5 +442,9 @@ module.exports = {
   WARN: {
     name: 'warningReason',
     type: 'text'
+  },
+  BMV: {
+    name: 'batteryMonitorName',
+    type: 'text'
   }
 }

--- a/lib/serial.js
+++ b/lib/serial.js
@@ -1,4 +1,5 @@
 const SerialPort = require('serialport')
+const Delimiter = require('@serialport/parser-delimiter')
 const debug = require('debug')('signalk-vedirect-parser')
 let port = null
 
@@ -12,7 +13,9 @@ exports.open = function openSerialConnection (device, parser) {
 
   port = new SerialPort(device, { baudRate: 19200 }) // @NOTE FT: should this be configurable?
 
-  port.on('data', chunk => {
+  const delim = port.pipe(new Delimiter({delimiter: '\r' , includeDelimiter: true}))
+
+  delim.on('data', chunk => {
     // Chunk is a node.js Buffer
     parser.addChunk(chunk)
   })


### PR DESCRIPTION
my SmartShunt 500A/50mV sends a "BMV" record as part of the VE.direct data frame, and the parser complains about it being an unknown type.