### PR TITLE
New feature: standalone usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ It's possible to use this plugin as a library, in other Node.js code. This featu
 ```javascript
 const VEDirect = require('@signalk/vedirect-serial-usb/standalone')
 const consumer = new VEDirect({
-  device: 'Serial',
-  connection: '/dev/ttyUSB0',
-  port: 7878, // ignored when "device" is set to "Serial"
+  device: '/dev/ttyUSB0',
   ignoreChecksum: true,
   mainBatt: 'House',
   auxBatt: 'Starter',

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatible Victron products:
 - BlueSolar Chargers
 - Phoenix Inverters, including the Smarts, having a VE.Direct comms port
 
-Note that above list may not be complete. 
+Note that above list may not be complete.
 
 The TCP and UDP connection methods are to allow connecting to a Victron product
 too far away to run a serial cable. Ie. using a bridge to LAN/Wi-Fi that takes
@@ -31,34 +31,60 @@ plugin. Details for that [here](https://github.com/sbender9/signalk-venus-plugin
 
 Use the Signal K app store or install via NPM in the Signal K server root directory: `npm install @signalk/vedirect-serial-usb`
 
-
 ### Usage
 
 Set up the appropiate device on the settings page of this plugin in the Signal K server admin UI, for instance to `/dev/ttyUSB0` and enable the plugin. Your VE.Direct data will be available in Signal K format via various clients and apps.
 
 ### Connections
+
 **Select device**
+
 - Serial, UDP or TCP
 
 **Connection details**
+
 - Serial: Enter device path e.g `/dev/ttyUSB0`
-- UDP: *`ignored`*
+- UDP: _`ignored`_
 - TCP: Enter host `IP address`
 
 **Port**
-- Serial: *`ignored`*
+
+- Serial: _`ignored`_
 - UDP/TCP: `port`
 
 **Ignore Checksum**
+
 - If you want to ignore checksum, use this option. Default `ON`
 
 **SK Paths**
-- Give each device unique SK paths 
+
+- Give each device unique SK paths
+
+### Usage as a library
+
+It's possible to use this plugin as a library, in other Node.js code. This feature simply wraps the plugin in an easy-to-consume manner, so functionality is identical. Example:
+
+```javascript
+const VEDirect = require('@signalk/vedirect-serial-usb/standalone')
+const consumer = new VEDirect({
+  device: 'Serial',
+  connection: '/dev/ttyUSB0',
+  port: 7878, // ignored when "device" is set to "Serial"
+  ignoreChecksum: true,
+  mainBatt: 'House',
+  auxBatt: 'Starter',
+  solar: 'Main',
+})
+
+consumer.on('delta', (delta) => console.log('[onDelta]', delta))
+consumer.stop() // stop the plugin, destruct the connections
+consumer.start() // (re-)start the plugin
+```
 
 ### License
 
 ```
-Copyright 2018 Joachim Bakke <github@heiamoss.com>, Fabian Tollenaar <fabian@decipher.industries> and 
+Copyright 2018 Joachim Bakke <github@heiamoss.com>, Fabian Tollenaar <fabian@decipher.industries> and
 Karl-Erik Gustafsson <ke.gustafsson@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const serial = require('./lib/serial')
 const udp = require('./lib/udp')
 const tcp = require('./lib/tcp')
 const Parser = require('./lib/Parser')
+const VEDirect = require('./standalone')
 
 module.exports = function (app) {
   let parser = []

--- a/lib/serial.js
+++ b/lib/serial.js
@@ -5,13 +5,14 @@ let delim = []
 
 module.exports = {
   open: (device, parser, debug, items) => {
-    console.log(port[items])
     if (typeof port[items] !== 'undefined' ) {
       try {
         port[items].close()
         port[items] = undefined
       } catch (e) {}
     }
+
+    debug(`Serial: connecting to ${device}`)
 
     port[items] = new SerialPort(device, { baudRate: 19200 }) // @NOTE FT: should this be configurable?
 

--- a/standalone.js
+++ b/standalone.js
@@ -12,6 +12,8 @@ const SKPlugin = require('./index')
 
 class VEDirect extends EventEmitter {
   constructor (config = {}) {
+    super()
+    
     this.app = {
       handleMessage () {},
       debug: true,

--- a/standalone.js
+++ b/standalone.js
@@ -13,13 +13,10 @@ class VEDirect extends EventEmitter {
   constructor (config = {}, _debug = false) {
     super()
 
+    this._debug = _debug
     this.app = {
       handleMessage: (kind, data) => this.emit(kind, data),
-      debug: (...args) => {
-        if (_debug === true) {
-          console.log.apply(console, args)
-        }
-      },
+      debug: (args) => this.debug(args),
       options: {
         device: 'Serial',
         connection: '/dev/ttyUSB0',
@@ -37,7 +34,8 @@ class VEDirect extends EventEmitter {
   }
 
   start () {
-    if (!this.plugin) {
+    if (!this.plugin || !this.plugin.hasOwnProperty('start')) {
+      this.debug(`Plugin not initialised, can't start`)
       return
     }
 
@@ -45,11 +43,18 @@ class VEDirect extends EventEmitter {
   }
 
   stop () {
-    if (!this.plugin) {
+    if (!this.plugin || !this.plugin.hasOwnProperty('stop')) {
+      this.debug(`Plugin not initialised, can't stop`)
       return
     }
 
     this.plugin.stop()
+  }
+
+  debug (...args) {
+    if (this._debug) {
+      console.log.apply(console, args)
+    }
   }
 }
 

--- a/standalone.js
+++ b/standalone.js
@@ -15,7 +15,13 @@ class VEDirect extends EventEmitter {
 
     this._debug = _debug
     this.app = {
-      handleMessage: (kind, data) => this.emit(kind, data),
+      handleMessage: (kind, data) => {
+        if (kind === 'pluginId') {
+          this.emit('delta', data)
+          return
+        }
+        this.emit(kind, data)
+      },
       debug: (args) => this.debug(args),
       options: {
         device: 'Serial',

--- a/standalone.js
+++ b/standalone.js
@@ -9,14 +9,17 @@
 
 const EventEmitter = require('events')
 const SKPlugin = require('./index')
-
 class VEDirect extends EventEmitter {
-  constructor (config = {}) {
+  constructor (config = {}, _debug = false) {
     super()
 
     this.app = {
       handleMessage: (kind, data) => this.emit(kind, data),
-      debug: true,
+      debug: (...args) => {
+        if (_debug === true) {
+          console.log.apply(console, args)
+        }
+      },
       options: {
         device: 'Serial',
         connection: '/dev/ttyUSB0',

--- a/standalone.js
+++ b/standalone.js
@@ -1,0 +1,60 @@
+/**
+ * standalone.js
+ * 
+ * @description exports a class that shims the Signal K server, in order to make this plugin available as a library in other software
+ * @module @signalk/vedirect-serial-usb
+ * @author Fabian Tollenaar <fabian@essense.ai> (https://essense.ai)
+ * @license Apache_2.0
+ */
+
+const EventEmitter = require('events')
+const SKPlugin = require('./index')
+
+class VEDirect extends EventEmitter {
+  constructor (config = {}) {
+    this.app = {
+      handleMessage () {},
+      debug: true,
+      options: {
+        device: 'Serial',
+        connection: '/dev/ttyUSB0',
+        port: 7878,
+        ignoreChecksum: true,
+        mainBatt: 'House',
+        auxBatt: 'Starter',
+        solar: 'Main',
+        ...(config || {}),
+      }
+    }
+
+    this.plugin = SKPlugin(this.app)
+    
+    this.plugin.on('delta', (delta) => {
+      this.emit('delta', delta)
+    })
+
+    this.plugin.on('error', (err) => {
+      this.emit('error', err)
+    })
+
+    this.start()
+  }
+
+  start () {
+    if (!this.plugin) {
+      return
+    }
+
+    this.plugin.start(this.app.options)
+  }
+
+  stop () {
+    if (!this.plugin) {
+      return
+    }
+
+    this.plugin.stop()
+  }
+}
+
+module.exports = VEDirect

--- a/standalone.js
+++ b/standalone.js
@@ -13,9 +13,9 @@ const SKPlugin = require('./index')
 class VEDirect extends EventEmitter {
   constructor (config = {}) {
     super()
-    
+
     this.app = {
-      handleMessage () {},
+      handleMessage: (kind, data) => this.emit(kind, data),
       debug: true,
       options: {
         device: 'Serial',
@@ -30,15 +30,6 @@ class VEDirect extends EventEmitter {
     }
 
     this.plugin = SKPlugin(this.app)
-    
-    this.plugin.on('delta', (delta) => {
-      this.emit('delta', delta)
-    })
-
-    this.plugin.on('error', (err) => {
-      this.emit('error', err)
-    })
-
     this.start()
   }
 


### PR DESCRIPTION
This PR adds a feature that allows stand-alone usage of the plugin, by wrapping the Signal K plugin definition. 