### PR TITLE
Put source ID in the source string

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -334,7 +334,8 @@ class VEDirectParser extends EventEmitter {
         {
           source: {
             label: '@signalk/vedirect-serial-usb',
-            type: 'VE.direct'
+            type: 'VE.direct',
+            src: `${items}`
           },
           timestamp: new Date().toISOString(),
           values


### PR DESCRIPTION
Use the items enumeration value in the source string to distinguish between different data sources. E.g., vedirect-signalk.0/1/2 rather than vedirect-signalk.XX for all VE.Direct inputs.