### PR TITLE
ci: add GitHub Actions workflows and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # npm: weekly bumps, groups minor+patch into one PR, majors individual
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions: weekly, one grouped PR for everything
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+          - major
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        if: matrix.node-version == '24.x'
+        run: npm run prettier:check
+
+      - name: Typecheck
+        if: matrix.node-version == '24.x'
+        run: npm run typecheck
+
+      - name: Build
+        if: matrix.node-version == '24.x'
+        run: npm run build
+
+      - name: Run tests
+        if: matrix.node-version != '24.x'
+        run: npm test
+
+      - name: Run tests with coverage
+        if: matrix.node-version == '24.x'
+        shell: bash
+        run: |
+          set -eo pipefail
+          npm run coverage | tee coverage.log
+
+      - name: Coverage step summary
+        if: matrix.node-version == '24.x'
+        shell: bash
+        run: |
+          {
+            echo '## Test Coverage'
+            echo
+            echo '```'
+            cat coverage.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage (lcov) as artifact
+        if: matrix.node-version == '24.x'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release
+    permissions:
+      id-token: write # OIDC trusted publishing
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Publish to npm
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          if [[ "$tag" == *alpha* ]]; then
+            npm publish --provenance --access public --tag alpha
+          elif [[ "$tag" == *beta* ]]; then
+            npm publish --provenance --access public --tag beta
+          elif [[ "$tag" == *rc* ]]; then
+            npm publish --provenance --access public --tag rc
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'fix, feature, doc, chore, dependencies'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+# Marks issues labeled "awaiting response" as stale after 30 days of inactivity
+# and closes them 30 days after that (60 days total). Issues labeled
+# "good first task" or "help wanted" are exempt. Pull requests are never
+# touched. The workflow runs daily and can also be triggered manually.
+name: Stale issues
+
+on:
+  schedule:
+    - cron: '17 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 30
+          stale-issue-label: 'stale'
+          any-of-issue-labels: 'awaiting response'
+          exempt-issue-labels: 'good first task,help wanted'
+          stale-issue-message: >
+            This issue is marked as awaiting a response from the reporter and
+            has had no activity for 30 days. It will be closed in another 30
+            days if there is no further update. If the issue is still
+            relevant, please reply with any missing information.
+          close-issue-message: >
+            Closing this issue because it has been stale for 60 days without
+            a response. Please reopen if this is still relevant.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 100


### PR DESCRIPTION
Part 3 of 4. Stacked on #68 (base: `refactor/typescript`).

Adds GitHub Actions and dependabot, mirroring the signalk-to-nmea0183 setup.

- `ci.yml`: prettier check, typecheck, build and tests on Node 20/22/24, with coverage + lcov artifact on Node 24.
- `publish.yml`: on `v*` tags, create a GitHub release and publish to npm via OIDC trusted publishing (provenance; alpha/beta/rc dist-tags). Requires a trusted publisher to be configured for `@signalk/vedirect-serial-usb` on npmjs.org.
- `require_pr_label.yml`: require exactly one of `fix` / `feature` / `doc` / `chore` / `dependencies` (these labels were created on the repo).
- `stale.yml`: mark "awaiting response" issues stale after 30 days and close after 60; pull requests are never touched.
- `dependabot.yml`: weekly npm and github-actions updates, grouped.