### PR TITLE
refactor: tighten types and simplify unit-id resolution

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -20,6 +20,7 @@ import type {
   PluginOptions,
   SKDelta,
   StoredField,
+  UnitId,
   VEDirectConnection
 } from './types'
 
@@ -32,7 +33,6 @@ interface ParserOptions extends PluginOptions {
   auxBatt: string
   bmv: string
   solar: string
-  overrideUnitId?: string
 }
 
 const defaults = {
@@ -65,7 +65,7 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     this.sum = 0
   }
 
-  addChunk(buf: Buffer, items: number): void {
+  addChunk(buf: Buffer, connectionIndex: number): void {
     if (!Buffer.isBuffer(buf)) {
       this.warn('addChunk: incoming data is not a buffer: ' + typeof buf)
       return
@@ -81,7 +81,7 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     if (chunk.toLowerCase().includes('checksum')) {
       // Last line of block. Verify checksum of block in cache and parse
       // line-by-line if checksum is correct.
-      this._verifyCacheAndParse(items)
+      this._verifyCacheAndParse(connectionIndex)
     }
   }
 
@@ -119,8 +119,8 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     return Object.assign({}, this.data)
   }
 
-  private _verifyCacheAndParse(items: number): void {
-    const conn = this.options.vedirect?.[items]
+  private _verifyCacheAndParse(connectionIndex: number): void {
+    const conn = this.options.vedirect?.[connectionIndex]
 
     // Verify checksum unless ignoreChecksum is explicitly true.
     if (conn?.ignoreChecksum !== true && this.sum % 256 !== 0) {
@@ -142,7 +142,7 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
 
     this.cache = ''
     this.sum = 0
-    this.generateDelta(items)
+    this.generateDelta(connectionIndex)
   }
 
   private _parse(): void {
@@ -339,10 +339,10 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     return this.options.productIds[key] ?? 'Unknown'
   }
 
-  generateDelta(items: number): void {
+  generateDelta(connectionIndex: number): void {
     const values = Object.keys(this.data)
       .map((name) => {
-        const path = this.getPath(name, items)
+        const path = this.getPath(name, connectionIndex)
         const entry = this.data[name]
         if (path === null || entry === undefined) {
           return null
@@ -376,45 +376,44 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     this.emit('delta', delta)
   }
 
-  getPath(name: string, items: number): string | null {
-    const conn: VEDirectConnection | undefined = this.options.vedirect?.[items]
+  getPath(name: string, connectionIndex: number): string | null {
+    const field = Object.values(this.fields).find(
+      (f) => f.name === name && f.path !== undefined
+    )
+    if (!field?.path) {
+      return null
+    }
+    if (field.unitId === undefined) {
+      return field.path
+    }
 
-    return Object.keys(this.fields).reduce<string | null>((found, key) => {
-      const field = this.fields[key]
-      if (!field || field.name !== name || field.path === undefined) {
-        return found
-      }
+    const conn = this.options.vedirect?.[connectionIndex]
+    return field.path.replace('*', this.resolveUnitId(field.unitId, conn))
+  }
 
-      let path = field.path
-
-      if (field.unitId !== undefined) {
-        let unitID = ''
-
-        if (conn) {
-          if (field.unitId === 'mainBatt') {
-            unitID = conn.mainBatt
-          } else if (field.unitId === 'auxBatt') {
-            unitID = conn.auxBatt
-          } else if (field.unitId === 'bmv') {
-            unitID = conn.bmv
-          } else if (field.unitId === 'solar') {
-            unitID = conn.solar
-          }
-        }
-
-        if (!unitID && typeof this.options.defaultUnitId === 'string') {
-          unitID = this.options.defaultUnitId
-        }
-
-        if (typeof this.options.overrideUnitId === 'string') {
-          unitID = this.options.overrideUnitId
-        }
-
-        path = path.replace('*', unitID)
-      }
-
-      return path
-    }, null)
+  /**
+   * Resolves a field's unit id to the configured device name. The four
+   * configurable units come from the connection; aux2Batt/inverter have no
+   * config slot and use defaultUnitId. The switch is exhaustive over UnitId,
+   * so adding a unit without handling it here is a compile error.
+   */
+  private resolveUnitId(
+    unitId: UnitId,
+    conn: VEDirectConnection | undefined
+  ): string {
+    switch (unitId) {
+      case 'mainBatt':
+        return conn?.mainBatt || this.options.defaultUnitId
+      case 'auxBatt':
+        return conn?.auxBatt || this.options.defaultUnitId
+      case 'bmv':
+        return conn?.bmv || this.options.defaultUnitId
+      case 'solar':
+        return conn?.solar || this.options.defaultUnitId
+      case 'aux2Batt':
+      case 'inverter':
+        return this.options.defaultUnitId
+    }
   }
 
   warn(message: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,20 +22,29 @@ const createPlugin = function (app: SignalKApp): Plugin {
   const parser: VEDirectParser[] = []
   let shaddow: PluginOptions | null = null
 
-  function startConnection(conn: VEDirectConnection, items: number): void {
+  function startConnection(
+    conn: VEDirectConnection,
+    connectionIndex: number
+  ): void {
     const instance = new VEDirectParser(shaddow ?? undefined)
-    parser[items] = instance
+    parser[connectionIndex] = instance
 
     instance.on('delta', (delta: SKDelta) => {
       app.handleMessage('pluginId', delta)
     })
 
     if (conn.device === 'Serial') {
-      serial.open(conn.connection, parser, app.debug, items)
+      serial.open(conn.connection, parser, app.debug, connectionIndex)
     } else if (conn.device === 'UDP') {
-      udp.listen(conn.port, parser, app.debug, items)
+      udp.listen(conn.port, parser, app.debug, connectionIndex)
     } else if (conn.device === 'TCP') {
-      tcp.connect(conn.connection, conn.port, parser, app.debug, items)
+      tcp.connect(
+        conn.connection,
+        conn.port,
+        parser,
+        app.debug,
+        connectionIndex
+      )
     }
   }
 
@@ -82,8 +91,8 @@ const createPlugin = function (app: SignalKApp): Plugin {
       shaddow = options
 
       if (options.vedirect !== undefined) {
-        options.vedirect.forEach((conn, items) => {
-          startConnection(conn, items)
+        options.vedirect.forEach((conn, connectionIndex) => {
+          startConnection(conn, connectionIndex)
         })
         return
       }
@@ -101,15 +110,15 @@ const createPlugin = function (app: SignalKApp): Plugin {
       }
 
       if (shaddow.vedirect !== undefined) {
-        shaddow.vedirect.forEach((conn, items) => {
-          parser[items]?.removeAllListeners()
-          delete parser[items]
+        shaddow.vedirect.forEach((conn, connectionIndex) => {
+          parser[connectionIndex]?.removeAllListeners()
+          delete parser[connectionIndex]
           if (conn.device === 'Serial') {
-            serial.close(app.debug, items)
+            serial.close(app.debug, connectionIndex)
           } else if (conn.device === 'UDP') {
-            udp.close(app.debug, items)
+            udp.close(app.debug, connectionIndex)
           } else {
-            tcp.close(app.debug, items)
+            tcp.close(app.debug, connectionIndex)
           }
         })
       }

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -3,7 +3,7 @@
  *
  * Opens a serial port per connection index, splits the stream on `\r`
  * (VE.Direct line terminator) and feeds each line into the matching parser.
- * Ports are tracked by `items` (the connection index) so that several
+ * Ports are tracked by `connectionIndex` (the connection index) so that several
  * configured connections can run side by side.
  */
 import { SerialPort } from 'serialport'
@@ -18,13 +18,13 @@ export function open(
   device: string,
   parser: VEDirectParser[],
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): void {
-  const existing = port[items]
+  const existing = port[connectionIndex]
   if (existing !== undefined) {
     try {
       existing.close()
-      port[items] = undefined
+      port[connectionIndex] = undefined
     } catch {
       // best-effort: the port may already be gone
     }
@@ -33,7 +33,7 @@ export function open(
   debug(`Serial: connecting to ${device}`)
 
   const sp = new SerialPort({ path: device, baudRate: 19200 })
-  port[items] = sp
+  port[connectionIndex] = sp
 
   sp.on('open', () => {
     debug(`Connected to ${device}`)
@@ -46,11 +46,11 @@ export function open(
   const parsed = sp.pipe(
     new DelimiterParser({ delimiter: '\r', includeDelimiter: true })
   )
-  delim[items] = parsed
+  delim[connectionIndex] = parsed
 
   parsed.on('data', (chunk: Buffer) => {
     // Chunk is a node.js Buffer
-    parser[items]?.addChunk(chunk, items)
+    parser[connectionIndex]?.addChunk(chunk, connectionIndex)
     debug(`${chunk}`)
   })
 
@@ -59,12 +59,12 @@ export function open(
   })
 }
 
-export function close(debug: DebugFn, items: number): void {
-  const sp = port[items]
+export function close(debug: DebugFn, connectionIndex: number): void {
+  const sp = port[connectionIndex]
   if (sp !== undefined) {
     try {
       sp.close()
-      port[items] = undefined
+      port[connectionIndex] = undefined
       debug('Serial port closed')
     } catch {
       // best-effort

--- a/src/tcp.ts
+++ b/src/tcp.ts
@@ -19,13 +19,13 @@ function makeConnection(
   host: string,
   port: number,
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): Net.Socket {
   const socket = new Net.Socket()
   socket.connect({ port, host })
   socket.setTimeout(SOCKET_TIMEOUT_MS)
   debug(`Connection to ${host}:${port}`)
-  client[items] = socket
+  client[connectionIndex] = socket
   return socket
 }
 
@@ -33,9 +33,9 @@ function onData(
   msg: Buffer,
   parser: VEDirectParser[],
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): void {
-  parser[items]?.addChunk(msg, items)
+  parser[connectionIndex]?.addChunk(msg, connectionIndex)
   debug(`${msg}`)
 }
 
@@ -44,13 +44,13 @@ function onClose(
   port: number,
   parser: VEDirectParser[],
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): void {
   // Only reconnect if the slot is still active (not cleared by close()).
-  if (client[items] !== undefined) {
+  if (client[connectionIndex] !== undefined) {
     setTimeout(() => {
       debug('Trying to reconnect')
-      connect(host, port, parser, debug, items)
+      connect(host, port, parser, debug, connectionIndex)
     }, RECONNECT_DELAY_MS)
   }
 }
@@ -60,18 +60,18 @@ export function connect(
   port: number,
   parser: VEDirectParser[],
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): void {
-  const socket = makeConnection(host, port, debug, items)
+  const socket = makeConnection(host, port, debug, connectionIndex)
 
   socket.on('data', (msg: Buffer) => {
-    onData(msg, parser, debug, items)
+    onData(msg, parser, debug, connectionIndex)
   })
 
   socket.on('close', () => {
     debug('TCP connection closed')
     socket.destroy()
-    onClose(host, port, parser, debug, items)
+    onClose(host, port, parser, debug, connectionIndex)
   })
 
   socket.on('error', () => {
@@ -85,10 +85,10 @@ export function connect(
   })
 }
 
-export function close(debug: DebugFn, items: number): void {
-  const socket = client[items]
+export function close(debug: DebugFn, connectionIndex: number): void {
+  const socket = client[connectionIndex]
   if (socket !== undefined) {
-    client[items] = undefined
+    client[connectionIndex] = undefined
     socket.destroy()
     debug('TCP port closed')
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,11 +99,27 @@ export type FieldValue = (
 
 export type FieldType = 'metric' | 'ratio' | 'text' | 'boolean' | 'count'
 
+/**
+ * Identifies which configured device name fills a field path's `*` placeholder.
+ * `mainBatt`/`auxBatt`/`bmv`/`solar` map to the per-connection config;
+ * `aux2Batt`/`inverter` have no config slot and fall back to the parser's
+ * `defaultUnitId`. Keeping this a union (rather than `string`) ties the field
+ * table to the resolver in `getPath`: adding a new unit here forces the switch
+ * there to handle it.
+ */
+export type UnitId =
+  | 'mainBatt'
+  | 'auxBatt'
+  | 'aux2Batt'
+  | 'bmv'
+  | 'solar'
+  | 'inverter'
+
 /** A field definition: how to name, place and convert one VE.Direct token. */
 export interface Field {
   name: string
   path?: string
-  unitId?: string
+  unitId?: UnitId
   units?: string
   type?: FieldType
   value?: FieldValue
@@ -117,7 +133,7 @@ export interface StoredField {
   name: string
   value: number | string
   path?: string
-  unitId?: string
+  unitId?: UnitId
   units?: string
   type?: FieldType
 }

--- a/src/udp.ts
+++ b/src/udp.ts
@@ -15,10 +15,10 @@ export function listen(
   port: number,
   parser: VEDirectParser[],
   debug: DebugFn,
-  items: number
+  connectionIndex: number
 ): void {
   const sock = dgram.createSocket({ type: 'udp4', reuseAddr: true })
-  socket[items] = sock
+  socket[connectionIndex] = sock
 
   sock.on('listening', () => {
     debug(`listening on UDP ${port}`)
@@ -26,17 +26,17 @@ export function listen(
 
   sock.on('message', (msg: Buffer, rinfo: dgram.RemoteInfo) => {
     debug(`${rinfo.address}:${rinfo.port}:${msg}`)
-    parser[items]?.addChunk(msg, items)
+    parser[connectionIndex]?.addChunk(msg, connectionIndex)
   })
 
   sock.bind(port)
 }
 
-export function close(debug: DebugFn, items: number): void {
-  const sock = socket[items]
+export function close(debug: DebugFn, connectionIndex: number): void {
+  const sock = socket[connectionIndex]
   if (sock !== undefined) {
     sock.close()
-    socket[items] = undefined
+    socket[connectionIndex] = undefined
     debug('UDP port closed')
   }
 }

--- a/test/getPath.ts
+++ b/test/getPath.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for VEDirectParser.getPath / unit-id resolution.
+ *
+ * Pins the behaviour that the field table's `unitId` is substituted into the
+ * `*` placeholder of a field path: the four configurable units come from the
+ * connection config, while aux2Batt/inverter (which have no config slot) fall
+ * back to the parser's defaultUnitId.
+ */
+import { expect } from 'chai'
+import { VEDirectParser } from '../src/Parser'
+
+const parser = new VEDirectParser({
+  vedirect: [
+    {
+      device: 'UDP',
+      connection: 'localhost',
+      port: 7878,
+      ignoreChecksum: true,
+      mainBatt: 'House',
+      auxBatt: 'Starter',
+      bmv: 'BMV',
+      solar: 'Main'
+    }
+  ]
+})
+
+describe('VEDirectParser.getPath unit-id resolution', () => {
+  it('substitutes the configured device name for the four configurable units', () => {
+    expect(parser.getPath('mainBattVoltage', 0)).to.equal(
+      'electrical.batteries.House.voltage'
+    )
+    expect(parser.getPath('auxBattVoltage', 0)).to.equal(
+      'electrical.batteries.Starter.voltage'
+    )
+    expect(parser.getPath('relay', 0)).to.equal(
+      'electrical.batteries.BMV.relay'
+    )
+    expect(parser.getPath('panelVoltage', 0)).to.equal(
+      'electrical.solar.Main.panelVoltage'
+    )
+  })
+
+  it('falls back to defaultUnitId for units without a config slot', () => {
+    // V3 -> aux2Batt, AC_OUT_V -> inverter; neither has a connection field.
+    expect(parser.getPath('aux2BattVoltage', 0)).to.equal(
+      'electrical.batteries.victronDevice.voltage'
+    )
+    expect(parser.getPath('acOutputVoltage', 0)).to.equal(
+      'electrical.ac.victronDevice.phase.A.lineLineVoltage'
+    )
+  })
+
+  it('returns null for fields without a Signal K path', () => {
+    expect(parser.getPath('firmwareVersion', 0)).to.equal(null)
+    expect(parser.getPath('serialNumber', 0)).to.equal(null)
+  })
+
+  it('uses defaultUnitId when the configured name is blank', () => {
+    const blank = new VEDirectParser({
+      vedirect: [
+        {
+          device: 'UDP',
+          connection: 'localhost',
+          port: 7878,
+          ignoreChecksum: true,
+          mainBatt: '',
+          auxBatt: 'Starter',
+          bmv: 'BMV',
+          solar: 'Main'
+        }
+      ]
+    })
+    expect(blank.getPath('mainBattVoltage', 0)).to.equal(
+      'electrical.batteries.victronDevice.voltage'
+    )
+  })
+})


### PR DESCRIPTION
Addresses the type-tightening findings from the review of the TypeScript migration.

- **`UnitId` union** (`types.ts`): `Field.unitId`/`StoredField.unitId` move from `string` to a `'mainBatt' | 'auxBatt' | 'aux2Batt' | 'bmv' | 'solar' | 'inverter'` union. This ties the field table to the resolver in `getPath` - adding a unit without handling it is now a compile error.
- **`getPath` rewrite** (`Parser.ts`): replaced the reduce-as-find with `Object.values(...).find(...)` plus an exhaustive `resolveUnitId` switch. Behavior is preserved, including `aux2Batt`/`inverter` (which have no per-connection config slot) falling back to `defaultUnitId`, and blank configured names falling back too.
- **Remove dead `overrideUnitId`**: it was read in `getPath` but never set by the schema, the standalone config, or defaults.
- **Rename `items` -> `connectionIndex`**: the connection-index parameter collided conceptually with the JSON-schema `items` keyword (which is left untouched in the schema).
- **Tests**: `test/getPath.ts` pins unit-id resolution across all six units, the no-path case, and the blank-name fallback.

Typecheck, build, tests (6) and prettier are green. Behavior-preserving; the unit tests assert the preserved path output.