### PR TITLE
fix: bound the parser cache and harden transport reconnects

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -45,6 +45,11 @@ const defaults = {
   solar: 'solar'
 }
 
+// A VE.Direct block is well under 1 KB. If far more than that accumulates
+// without a Checksum line, the stream is malformed or the sentinel was lost;
+// the cache is dropped rather than left to grow unbounded from device input.
+const MAX_CACHE_LENGTH = 8192
+
 export class VEDirectParser extends EventEmitter implements FieldContext {
   options: ParserOptions
   fields: FieldMap
@@ -82,6 +87,15 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
       // Last line of block. Verify checksum of block in cache and parse
       // line-by-line if checksum is correct.
       this._verifyCacheAndParse(connectionIndex)
+      return
+    }
+
+    if (this.cache.length > MAX_CACHE_LENGTH) {
+      this.warn(
+        `block exceeded ${MAX_CACHE_LENGTH} bytes without a Checksum line; discarding`
+      )
+      this.cache = ''
+      this.sum = 0
     }
   }
 

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -3,16 +3,21 @@
  *
  * Opens a serial port per connection index, splits the stream on `\r`
  * (VE.Direct line terminator) and feeds each line into the matching parser.
- * Ports are tracked by `connectionIndex` (the connection index) so that several
- * configured connections can run side by side.
+ * If the port closes unexpectedly (e.g. the USB cable is unplugged) it is
+ * re-opened after a back-off, unless it was deliberately closed via `close()`
+ * (which clears the slot and cancels any pending reconnect). Ports are tracked
+ * by connection index so several connections can run side by side.
  */
 import { SerialPort } from 'serialport'
 import { DelimiterParser } from '@serialport/parser-delimiter'
 import type { VEDirectParser } from './Parser'
 import type { DebugFn } from './types'
 
+const BAUD_RATE = 19200
+const RECONNECT_DELAY_MS = 10000
+
 const port: (SerialPort | undefined)[] = []
-const delim: (DelimiterParser | undefined)[] = []
+const reconnectTimer: (ReturnType<typeof setTimeout> | undefined)[] = []
 
 export function open(
   device: string,
@@ -20,19 +25,11 @@ export function open(
   debug: DebugFn,
   connectionIndex: number
 ): void {
-  const existing = port[connectionIndex]
-  if (existing !== undefined) {
-    try {
-      existing.close()
-      port[connectionIndex] = undefined
-    } catch {
-      // best-effort: the port may already be gone
-    }
-  }
+  closePort(connectionIndex)
 
   debug(`Serial: connecting to ${device}`)
 
-  const sp = new SerialPort({ path: device, baudRate: 19200 })
+  const sp = new SerialPort({ path: device, baudRate: BAUD_RATE })
   port[connectionIndex] = sp
 
   sp.on('open', () => {
@@ -46,7 +43,6 @@ export function open(
   const parsed = sp.pipe(
     new DelimiterParser({ delimiter: '\r', includeDelimiter: true })
   )
-  delim[connectionIndex] = parsed
 
   parsed.on('data', (chunk: Buffer) => {
     // Chunk is a node.js Buffer
@@ -55,19 +51,47 @@ export function open(
   })
 
   sp.on('error', (err: Error) => {
-    debug('SerialPort error: ' + err.message)
+    debug(`SerialPort error on ${device}: ${err.message}`)
+  })
+
+  sp.on('close', () => {
+    // Reconnect only if this is still the active port for the slot. A deliberate
+    // close() clears the slot first, and a re-open replaces it, so in both cases
+    // the stale port must not trigger a reconnect.
+    if (port[connectionIndex] === sp) {
+      debug(
+        `Serial port ${device} closed; reconnecting in ${RECONNECT_DELAY_MS}ms`
+      )
+      reconnectTimer[connectionIndex] = setTimeout(() => {
+        reconnectTimer[connectionIndex] = undefined
+        open(device, parser, debug, connectionIndex)
+      }, RECONNECT_DELAY_MS)
+    }
   })
 }
 
 export function close(debug: DebugFn, connectionIndex: number): void {
+  closePort(connectionIndex)
+  debug('Serial port closed')
+}
+
+// Cancels any pending reconnect and closes the active port for a slot. The slot
+// is cleared before close() so the port's 'close' handler does not schedule a
+// reconnect for a deliberate teardown.
+function closePort(connectionIndex: number): void {
+  const timer = reconnectTimer[connectionIndex]
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    reconnectTimer[connectionIndex] = undefined
+  }
+
   const sp = port[connectionIndex]
   if (sp !== undefined) {
+    port[connectionIndex] = undefined
     try {
       sp.close()
-      port[connectionIndex] = undefined
-      debug('Serial port closed')
     } catch {
-      // best-effort
+      // best-effort: the port may already be gone
     }
   }
 }

--- a/src/tcp.ts
+++ b/src/tcp.ts
@@ -4,7 +4,7 @@
  * Connects to a host:port that bridges a remote VE.Direct device onto the
  * network and feeds the received bytes into the matching parser. On close the
  * socket is re-dialled after a back-off, unless it was deliberately closed via
- * `close()` (which clears the slot so no reconnect is scheduled).
+ * `close()` (which clears the slot and cancels any pending reconnect).
  */
 import * as Net from 'net'
 import type { VEDirectParser } from './Parser'
@@ -14,6 +14,7 @@ const RECONNECT_DELAY_MS = 10000
 const SOCKET_TIMEOUT_MS = 5000
 
 const client: (Net.Socket | undefined)[] = []
+const reconnectTimer: (ReturnType<typeof setTimeout> | undefined)[] = []
 
 function makeConnection(
   host: string,
@@ -46,10 +47,12 @@ function onClose(
   debug: DebugFn,
   connectionIndex: number
 ): void {
-  // Only reconnect if the slot is still active (not cleared by close()).
+  // Only reconnect if the slot is still active (not cleared by close()). The
+  // timer handle is tracked so close() can cancel a pending reconnect.
   if (client[connectionIndex] !== undefined) {
-    setTimeout(() => {
-      debug('Trying to reconnect')
+    reconnectTimer[connectionIndex] = setTimeout(() => {
+      reconnectTimer[connectionIndex] = undefined
+      debug(`Trying to reconnect to ${host}:${port}`)
       connect(host, port, parser, debug, connectionIndex)
     }, RECONNECT_DELAY_MS)
   }
@@ -69,23 +72,29 @@ export function connect(
   })
 
   socket.on('close', () => {
-    debug('TCP connection closed')
+    debug(`TCP connection to ${host}:${port} closed`)
     socket.destroy()
     onClose(host, port, parser, debug, connectionIndex)
   })
 
-  socket.on('error', () => {
-    debug('TCP connection error')
+  socket.on('error', (err: Error) => {
+    debug(`TCP connection error ${host}:${port}: ${err.message}`)
     socket.destroy()
   })
 
   socket.on('timeout', () => {
-    debug('TCP connection timeout')
+    debug(`TCP connection timeout ${host}:${port}`)
     socket.destroy()
   })
 }
 
 export function close(debug: DebugFn, connectionIndex: number): void {
+  const timer = reconnectTimer[connectionIndex]
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    reconnectTimer[connectionIndex] = undefined
+  }
+
   const socket = client[connectionIndex]
   if (socket !== undefined) {
     client[connectionIndex] = undefined

--- a/test/cacheBound.ts
+++ b/test/cacheBound.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests the parser's bounded cache: a stream that never emits a Checksum line
+ * must not grow the in-memory cache without limit, while a normal block still
+ * accumulates until its Checksum arrives.
+ */
+import { expect } from 'chai'
+import { VEDirectParser } from '../src/Parser'
+import type { PluginOptions } from '../src/types'
+
+const config: PluginOptions = {
+  vedirect: [
+    {
+      device: 'UDP',
+      connection: 'localhost',
+      port: 7878,
+      ignoreChecksum: true,
+      mainBatt: 'House',
+      auxBatt: 'Starter',
+      bmv: 'bmv',
+      solar: 'Main'
+    }
+  ]
+}
+
+describe('VEDirectParser cache bound', () => {
+  it('discards an over-long block that never terminates with a Checksum', () => {
+    const parser = new VEDirectParser(config)
+
+    let warned = false
+    parser.on('warn', () => {
+      warned = true
+    })
+
+    // Feed well over the cache cap with no "Checksum" line.
+    const junk = Buffer.from(`X\t${'A'.repeat(1000)}\n`)
+    for (let i = 0; i < 12; i++) {
+      parser.addChunk(junk, 0)
+    }
+
+    expect(warned).to.equal(true)
+    expect(parser.cache.length).to.be.lessThan(8192)
+  })
+
+  it('keeps buffering a normal block until its Checksum arrives', () => {
+    const parser = new VEDirectParser(config)
+
+    const deltas: unknown[] = []
+    parser.on('delta', (d) => deltas.push(d))
+
+    parser.addChunk(Buffer.from('\nV\t12000\n'), 0)
+    expect(parser.cache.length).to.be.greaterThan(0) // still buffering
+    expect(deltas.length).to.equal(0)
+
+    parser.addChunk(Buffer.from('Checksum\t?\n'), 0)
+    expect(deltas.length).to.equal(1) // block completed and emitted
+    expect(parser.cache).to.equal('') // reset after parse
+  })
+})


### PR DESCRIPTION
Addresses the pre-existing reliability findings from the review. All of these were carried over verbatim from the original JavaScript - none were introduced by the TypeScript migration - but the review flagged them and this lands the fixes.

Stacked on #77 (base: `refactor/tighten-types`); merge #77 first.

- **Bounded parser cache** (`Parser.ts`): cap the accumulation cache at 8 KB. A VE.Direct block is well under 1 KB, so a stream that never sends a `Checksum` line (malformed device, lost sentinel, or hostile UDP/TCP input) no longer grows `this.cache` without bound and risk OOM-ing the signalk-server process.
- **Cancellable TCP reconnect** (`tcp.ts`): the 10s reconnect timer is now tracked so `close()`/`stop()` cancels a pending reconnect. Previously a `close` event slipping past the guard right before `stop()` could resurrect a zombie connection that nothing would close. Error/timeout logs now include `host:port` and the error message.
- **Serial reconnect** (`serial.ts`): the port now re-opens after a back-off when it closes unexpectedly (e.g. a USB cable unplug), cancellable on `close()` via a `port === sp` guard. Previously a serial drop was a silent outage until manual restart. Logs include the device and error message.

**Caveat:** the serial reconnect mirrors the already-shipped TCP reconnect pattern but I could not exercise it against real VE.Direct hardware in this environment. Worth a look on-device.

Typecheck, build, tests (8, incl. new bounded-cache tests) and prettier are green locally.