### PR TITLE
fix: emit null for infinite time-to-go (TTG -1)

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -187,12 +187,15 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     const converted =
       typeof field.value === 'function' ? field.value(rawData, this) : rawData
 
-    if (typeof converted !== 'undefined' && converted !== null) {
+    // undefined skips the field, leaving any prior value untouched; null is
+    // stored as an explicit null so it clears the value downstream in the
+    // delta (see FieldValue). Only undefined means "no update".
+    if (converted !== undefined) {
       this.set(field.name, { ...field, value: converted })
     }
   }
 
-  getAlarmReason(alarmReason: string | number): string | null {
+  getAlarmReason(alarmReason: string | number): string | undefined {
     switch (parseInt(String(alarmReason), 10)) {
       case 1:
         return 'Low voltage'
@@ -231,11 +234,11 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return 'High V AC out'
 
       default:
-        return null
+        return undefined
     }
   }
 
-  getErrorString(err: string | number): string | null {
+  getErrorString(err: string | number): string | undefined {
     switch (parseInt(String(err), 10)) {
       case 2:
         return 'Battery voltage too high'
@@ -279,11 +282,11 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return 'User settings invalid'
 
       default:
-        return null
+        return undefined
     }
   }
 
-  getMode(mode: string | number): string | null {
+  getMode(mode: string | number): string | undefined {
     switch (parseInt(String(mode), 10)) {
       case 2:
         return 'on'
@@ -295,11 +298,11 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return 'eco'
 
       default:
-        return null
+        return undefined
     }
   }
 
-  getStateOfOperation(cs: string | number): string | null {
+  getStateOfOperation(cs: string | number): string | undefined {
     switch (parseInt(String(cs), 10)) {
       case 0:
         return 'off'
@@ -323,11 +326,11 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return 'inverting'
 
       default:
-        return null
+        return undefined
     }
   }
 
-  getTrackerOperationMode(mppt: string | number): string | null {
+  getTrackerOperationMode(mppt: string | number): string | undefined {
     switch (parseInt(String(mppt), 10)) {
       case 0:
         return 'off'
@@ -339,7 +342,7 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return 'mpp tracker active'
 
       default:
-        return null
+        return undefined
     }
   }
 
@@ -364,7 +367,7 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         return { path, value: entry.value }
       })
       .filter(
-        (update): update is { path: string; value: number | string } =>
+        (update): update is { path: string; value: number | string | null } =>
           update !== null
       )
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -4,44 +4,45 @@
  * Maps each VE.Direct text-protocol label (e.g. `V`, `SOC`, `PID`) to how it
  * is named, where it lands in the Signal K tree (`path`, with `*` replaced by
  * the configured unit id) and how its raw token is converted. A field with no
- * `value` function stores the raw string; a function returning null/undefined
- * is skipped.
+ * `value` function stores the raw string. A `value` function returns the value
+ * to store, `undefined` to skip the field (leaving any prior value untouched),
+ * or `null` to store an explicit null that clears the value in Signal K.
  */
 import type { FieldMap } from './types'
 
 /** Numeric converters shared across fields. Each accepts the raw token (a
  *  string from the wire, occasionally an already-numeric value) and returns
- *  the scaled number, or null when the token is not a number. */
+ *  the scaled number, or undefined when the token is not a number (skip). */
 const common = {
-  number(value: string | number): number | null {
+  number(value: string | number): number | undefined {
     const n = typeof value === 'number' ? value : parseInt(value, 10)
-    return isNaN(n) ? null : n
+    return isNaN(n) ? undefined : n
   },
 
   // value is in units of 0.01 kWh each
-  kWh(value: string | number): number | null {
+  kWh(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === null ? null : n / 100
+    return n === undefined ? undefined : n / 100
   },
 
-  mV(value: string | number): number | null {
+  mV(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === null ? null : n / 1000
+    return n === undefined ? undefined : n / 1000
   },
 
-  mA(value: string | number): number | null {
+  mA(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === null ? null : Math.floor(n / 10) / 100
+    return n === undefined ? undefined : Math.floor(n / 10) / 100
   },
 
-  mAh(value: string | number): number | null {
+  mAh(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === null ? null : (Math.floor(n / 10) / 100) * 3600
+    return n === undefined ? undefined : (Math.floor(n / 10) / 100) * 3600
   },
 
-  promille(value: string | number): number | null {
+  promille(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === null ? null : n / 1000
+    return n === undefined ? undefined : n / 1000
   }
 }
 
@@ -152,7 +153,7 @@ const fields: FieldMap = {
     type: 'metric',
     value: (value) => {
       const n = common.number(value)
-      return n === null ? null : n + 273.15
+      return n === undefined ? undefined : n + 273.15
     }
   },
   P: {
@@ -180,10 +181,17 @@ const fields: FieldMap = {
     name: 'timeToGo',
     path: 'electrical.batteries.*.capacity.timeRemaining',
     unitId: 'mainBatt',
+    // Time-to-go is reported in minutes. -1 is the documented "infinite"
+    // sentinel (the battery is not discharging); it becomes an explicit null so
+    // Signal K clears any prior estimate rather than showing a negative time. A
+    // non-numeric token is a garbled read and is skipped, leaving the last value.
+    // Input "600" -> 36000 (s);  "-1" -> null (clear);  "-" -> undefined (skip)
     value: (value) => {
       const n = common.number(value)
-      // value is minutes
-      return n === null ? null : n * 60
+      if (n === undefined) {
+        return undefined
+      }
+      return n === -1 ? null : n * 60
     },
     units: 's',
     type: 'metric'
@@ -379,7 +387,7 @@ const fields: FieldMap = {
         name: 'productId',
         value: instance.getProductLongname(pid)
       })
-      return null
+      return undefined
     }
   },
   'SER#': {
@@ -405,7 +413,7 @@ const fields: FieldMap = {
     value: (value) => {
       const n = common.number(value)
       // AC OUT V is reported in units of 0.01 V each.
-      return n === null ? null : n / 100
+      return n === undefined ? undefined : n / 100
     }
   },
   AC_OUT_I: {
@@ -417,7 +425,7 @@ const fields: FieldMap = {
     value: (value) => {
       const n = common.number(value)
       // AC OUT I is reported in units of 0.1 A each.
-      return n === null ? null : n / 10
+      return n === undefined ? undefined : n / 10
     }
   },
   WARN: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,13 +85,15 @@ export interface SKDelta {
   updates: Array<{
     source: { label: string; type: string }
     timestamp: string
-    values: Array<{ path: string; value: number | string }>
+    values: Array<{ path: string; value: number | string | null }>
   }>
 }
 
 /** Converts a raw VE.Direct token into a Signal K value. Receives the raw
- *  token and the parser (for cross-field lookups and enum decoding), and
- *  returns the value to store, or null/undefined to skip it. */
+ *  token and the parser (for cross-field lookups and enum decoding). Returns
+ *  the value to store; `undefined` to skip the field, leaving any prior value
+ *  untouched; or `null` to store an explicit null, which clears the value in
+ *  Signal K (e.g. TTG -1, an infinite time-to-go). */
 export type FieldValue = (
   value: string,
   instance: FieldContext
@@ -131,7 +133,7 @@ export type FieldMap = Record<string, Field>
  *  on the parser. */
 export interface StoredField {
   name: string
-  value: number | string
+  value: number | string | null
   path?: string
   unitId?: UnitId
   units?: string
@@ -142,10 +144,10 @@ export interface StoredField {
  *  Implemented by VEDirectParser. */
 export interface FieldContext {
   set(key: string, value: StoredField): void
-  getAlarmReason(value: string | number): string | null
-  getErrorString(value: string | number): string | null
-  getStateOfOperation(value: string | number): string | null
-  getMode(value: string | number): string | null
-  getTrackerOperationMode(value: string | number): string | null
+  getAlarmReason(value: string | number): string | undefined
+  getErrorString(value: string | number): string | undefined
+  getStateOfOperation(value: string | number): string | undefined
+  getMode(value: string | number): string | undefined
+  getTrackerOperationMode(value: string | number): string | undefined
   getProductLongname(value: string): string
 }

--- a/test/integration/realCapture.ts
+++ b/test/integration/realCapture.ts
@@ -43,7 +43,7 @@ const CAPTURE: ReadonlyArray<readonly [string, string]> = [
 describe('integration: real BlueSolar MPPT 75/10 capture', () => {
   let parser: VEDirectParser
   let delta: SKDelta
-  let values: Array<{ path: string; value: number | string }>
+  let values: Array<{ path: string; value: number | string | null }>
 
   before(() => {
     const run = runBlock(toBlock(CAPTURE))
@@ -53,7 +53,7 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
     values = delta.updates[0]!.values
   })
 
-  const valueAt = (path: string): number | string => {
+  const valueAt = (path: string): number | string | null => {
     const found = values.find((v) => v.path === path)
     expect(found, `expected a value at ${path}`).to.not.equal(undefined)
     return found!.value
@@ -70,8 +70,8 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
 
   it('decodes every path-mapped field with the correct unit conversion', () => {
     // Only fields with a Signal K path appear in the delta; FW, SER#, HSDS and
-    // the product id/name are decoded but have no path, and ERR 0 maps to null
-    // (no error) so it is skipped.
+    // the product id/name are decoded but have no path, and ERR 0 maps to
+    // undefined (no error) so it is skipped.
     expect(values).to.have.lengthOf(12)
 
     // Battery (mainBatt -> "House"): mV and mA conversions.

--- a/test/integration/sampleStream.ts
+++ b/test/integration/sampleStream.ts
@@ -138,4 +138,22 @@ describe('integration: noisy BMV-702 stream', () => {
       'malformed lines produce warnings'
     ).to.be.greaterThan(0)
   })
+
+  it('clears time-to-go to null end-to-end when the BMV reports -1', () => {
+    // The stream's only well-formed TTG line is "TTG\t-1" (infinite). Through
+    // the full addChunk -> checksum -> parse -> generateDelta pipeline that must
+    // surface as an explicit null clearing the path, never -60 or a stale value.
+    const timeRemaining = deltas.flatMap((d) =>
+      d.updates[0]!.values.filter(
+        (v) => v.path === 'electrical.batteries.House.capacity.timeRemaining'
+      )
+    )
+    expect(
+      timeRemaining.length,
+      'time-to-go reached a delta'
+    ).to.be.greaterThan(0)
+    for (const v of timeRemaining) {
+      expect(v.value, 'infinite time-to-go is cleared to null').to.equal(null)
+    }
+  })
 })

--- a/test/unit/Parser.ts
+++ b/test/unit/Parser.ts
@@ -146,7 +146,7 @@ describe('VEDirectParser - parse()', () => {
     expect(parser.get('firmwareVersion')?.value).to.equal('0150')
   })
 
-  it('skips a field whose converter returns null', () => {
+  it('skips a field whose converter returns undefined', () => {
     parser.parse('V\tnot-a-number')
     expect(parser.get('mainBattVoltage')).to.equal(undefined)
   })
@@ -284,8 +284,8 @@ describe('VEDirectParser - addChunk() and checksum', () => {
 describe('VEDirectParser - enum decoders', () => {
   const parser = new VEDirectParser(CONNECTION)
 
-  it('decodes every alarm reason and falls through to null', () => {
-    const cases: Array<[number, string | null]> = [
+  it('decodes every alarm reason and falls through to undefined', () => {
+    const cases: Array<[number, string | undefined]> = [
       [1, 'Low voltage'],
       [2, 'High voltage'],
       [4, 'Low state-of-charge'],
@@ -298,8 +298,8 @@ describe('VEDirectParser - enum decoders', () => {
       [512, 'DC ripple'],
       [1024, 'Low V AC out'],
       [2048, 'High V AC out'],
-      [0, null],
-      [3, null]
+      [0, undefined],
+      [3, undefined]
     ]
     for (const [input, expected] of cases) {
       expect(parser.getAlarmReason(input), `AR ${input}`).to.equal(expected)
@@ -308,8 +308,8 @@ describe('VEDirectParser - enum decoders', () => {
     expect(parser.getAlarmReason('256')).to.equal('Overload')
   })
 
-  it('decodes every error code and falls through to null', () => {
-    const cases: Array<[number, string | null]> = [
+  it('decodes every error code and falls through to undefined', () => {
+    const cases: Array<[number, string | undefined]> = [
       [2, 'Battery voltage too high'],
       [17, 'Charger temperature too high'],
       [18, 'Charger overcurrent'],
@@ -321,8 +321,8 @@ describe('VEDirectParser - enum decoders', () => {
       [116, 'Factory calibration data lost'],
       [117, 'Invalid/incompatible firmware'],
       [119, 'User settings invalid'],
-      [0, null],
-      [19, null] // documented as ignorable -> null
+      [0, undefined],
+      [19, undefined] // documented as ignorable -> undefined
     ]
     for (const [input, expected] of cases) {
       expect(parser.getErrorString(input), `ERR ${input}`).to.equal(expected)
@@ -330,15 +330,15 @@ describe('VEDirectParser - enum decoders', () => {
     expect(parser.getErrorString('2')).to.equal('Battery voltage too high')
   })
 
-  it('decodes device mode and falls through to null', () => {
+  it('decodes device mode and falls through to undefined', () => {
     expect(parser.getMode(2)).to.equal('on')
     expect(parser.getMode(4)).to.equal('off')
     expect(parser.getMode(5)).to.equal('eco')
-    expect(parser.getMode(1)).to.equal(null)
+    expect(parser.getMode(1)).to.equal(undefined)
   })
 
-  it('decodes charger state of operation and falls through to null', () => {
-    const cases: Array<[number, string | null]> = [
+  it('decodes charger state of operation and falls through to undefined', () => {
+    const cases: Array<[number, string | undefined]> = [
       [0, 'off'],
       [1, 'low power'],
       [2, 'fault'],
@@ -346,7 +346,7 @@ describe('VEDirectParser - enum decoders', () => {
       [4, 'absorption'],
       [5, 'float'],
       [9, 'inverting'],
-      [7, null]
+      [7, undefined]
     ]
     for (const [input, expected] of cases) {
       expect(parser.getStateOfOperation(input), `CS ${input}`).to.equal(
@@ -355,13 +355,13 @@ describe('VEDirectParser - enum decoders', () => {
     }
   })
 
-  it('decodes tracker operation mode and falls through to null', () => {
+  it('decodes tracker operation mode and falls through to undefined', () => {
     expect(parser.getTrackerOperationMode(0)).to.equal('off')
     expect(parser.getTrackerOperationMode(1)).to.equal(
       'voltage or current limited'
     )
     expect(parser.getTrackerOperationMode(2)).to.equal('mpp tracker active')
-    expect(parser.getTrackerOperationMode(3)).to.equal(null)
+    expect(parser.getTrackerOperationMode(3)).to.equal(undefined)
   })
 })
 
@@ -507,6 +507,51 @@ describe('VEDirectParser - generateDelta()', () => {
     expect(new Date(update.timestamp).toISOString()).to.equal(update.timestamp)
     expect(update.values).to.deep.equal([
       { path: 'electrical.batteries.House.voltage', value: 12.34 }
+    ])
+  })
+})
+
+describe('VEDirectParser - clearing values (explicit null)', () => {
+  let parser: VEDirectParser
+  beforeEach(() => {
+    parser = new VEDirectParser(CONNECTION)
+  })
+
+  it('stores an explicit null when a converter returns null', () => {
+    // A null return means "clear this reading" (TTG -1 = infinite), distinct
+    // from undefined which means "skip". The store must hold the null so a
+    // prior value is overwritten rather than left stale.
+    parser.parse('TTG\t-1')
+    expect(
+      parser.get('timeToGo'),
+      'timeToGo is stored, not skipped'
+    ).to.not.equal(undefined)
+    expect(parser.get('timeToGo')?.value).to.equal(null)
+  })
+
+  it('overwrites a prior finite time-to-go with null when it goes infinite', () => {
+    // Regression for the discharge -> charge transition: once charging starts
+    // the BMV reports TTG -1, and the consumer must see null rather than the
+    // stale estimate (or the old -60 from naive minutes*60 on -1).
+    parser.parse('TTG\t600')
+    expect(parser.get('timeToGo')?.value).to.equal(36000)
+    parser.parse('TTG\t-1')
+    expect(parser.get('timeToGo')?.value).to.equal(null)
+  })
+
+  it('emits the cleared value as null in the generated delta', () => {
+    const deltas: SKDelta[] = []
+    parser.on('delta', (d: SKDelta) => deltas.push(d))
+
+    parser.parse('TTG\t-1')
+    parser.generateDelta(0)
+
+    expect(deltas).to.have.lengthOf(1)
+    expect(deltas[0]!.updates[0]!.values).to.deep.equal([
+      {
+        path: 'electrical.batteries.House.capacity.timeRemaining',
+        value: null
+      }
     ])
   })
 })

--- a/test/unit/fields.ts
+++ b/test/unit/fields.ts
@@ -47,10 +47,10 @@ function convert(
 
 describe('fields - numeric converters', () => {
   // common.number, reached via PPV (panelPower).
-  it('parses integers and rejects non-numbers (number)', () => {
+  it('parses integers and skips non-numbers (number)', () => {
     expect(convert('PPV', '42')).to.equal(42)
     expect(convert('PPV', '-7')).to.equal(-7)
-    expect(convert('PPV', 'not-a-number')).to.equal(null)
+    expect(convert('PPV', 'not-a-number')).to.equal(undefined)
   })
 
   it('passes an already-numeric token through without re-parsing (number)', () => {
@@ -61,30 +61,30 @@ describe('fields - numeric converters', () => {
 
   it('scales millivolts to volts (mV)', () => {
     expect(convert('V', '12340')).to.equal(12.34)
-    expect(convert('V', 'x')).to.equal(null)
+    expect(convert('V', 'x')).to.equal(undefined)
   })
 
   it('floors tenths of a milliamp before scaling to amps (mA)', () => {
     // 2779 -> floor(277.9)=277 -> 2.77 (the floor must not round up to 2.78).
     expect(convert('I', '2779')).to.equal(2.77)
     expect(convert('I', '2770')).to.equal(2.77)
-    expect(convert('I', 'x')).to.equal(null)
+    expect(convert('I', 'x')).to.equal(undefined)
   })
 
   it('converts consumed charge to coulombs (mAh)', () => {
     // 1000 -> floor(100)/100=1 Ah -> 1 * 3600 = 3600 C.
     expect(convert('CE', '1000')).to.equal(3600)
-    expect(convert('CE', 'x')).to.equal(null)
+    expect(convert('CE', 'x')).to.equal(undefined)
   })
 
   it('scales hundredths of a kWh to kWh (kWh)', () => {
     expect(convert('H17', '6078')).to.equal(60.78)
-    expect(convert('H17', 'x')).to.equal(null)
+    expect(convert('H17', 'x')).to.equal(undefined)
   })
 
   it('scales per-mille to a ratio (promille)', () => {
     expect(convert('SOC', '1000')).to.equal(1)
-    expect(convert('SOC', 'x')).to.equal(null)
+    expect(convert('SOC', 'x')).to.equal(undefined)
   })
 })
 
@@ -92,12 +92,22 @@ describe('fields - bespoke value functions', () => {
   it('offsets battery temperature into kelvin and rejects NaN', () => {
     expect(convert('T', '0')).to.equal(273.15)
     expect(convert('T', '25')).to.equal(298.15)
-    expect(convert('T', 'x')).to.equal(null)
+    expect(convert('T', 'x')).to.equal(undefined)
   })
 
-  it('converts time-to-go from minutes to seconds (TTG)', () => {
-    expect(convert('TTG', '10')).to.equal(600) // 10 min * 60
-    expect(convert('TTG', 'x')).to.equal(null)
+  it('converts time-to-go from minutes to seconds, clears on infinite (TTG)', () => {
+    // VE.Direct reports time-to-go in minutes; -1 is the documented "infinite"
+    // sentinel (the battery is not discharging). It must become an explicit
+    // null so Signal K clears any prior estimate, never a negative time. Only
+    // -1 is special: 0 and other negatives scale normally, and a non-numeric
+    // token is a garbled read that is skipped, leaving the last value intact.
+    // Input "600" -> 36000 (s);  "0" -> 0;  "-2" -> -120;  "-1" -> null (clear);
+    //       "-" -> undefined (skip)
+    expect(convert('TTG', '600')).to.equal(36000)
+    expect(convert('TTG', '0')).to.equal(0)
+    expect(convert('TTG', '-2')).to.equal(-120)
+    expect(convert('TTG', '-1')).to.equal(null)
+    expect(convert('TTG', '-')).to.equal(undefined)
   })
 
   it('lowercases the load output state', () => {
@@ -114,12 +124,12 @@ describe('fields - bespoke value functions', () => {
 
   it('scales AC output voltage (0.01 V units) and rejects NaN', () => {
     expect(convert('AC_OUT_V', '24000')).to.equal(240)
-    expect(convert('AC_OUT_V', 'x')).to.equal(null)
+    expect(convert('AC_OUT_V', 'x')).to.equal(undefined)
   })
 
   it('scales AC output current (0.1 A units) and rejects NaN', () => {
     expect(convert('AC_OUT_I', '15')).to.equal(1.5)
-    expect(convert('AC_OUT_I', 'x')).to.equal(null)
+    expect(convert('AC_OUT_I', 'x')).to.equal(undefined)
   })
 
   it('delegates enum fields to the parser decoders', () => {
@@ -133,7 +143,9 @@ describe('fields - bespoke value functions', () => {
   it('decodes PID into productId/productName side effects (with 0x prefix)', () => {
     const { ctx, sets } = makeContext()
     const result = convert('PID', '0xA053', ctx)
-    expect(result, 'PID stores via set() and returns null').to.equal(null)
+    expect(result, 'PID stores via set() and returns undefined').to.equal(
+      undefined
+    )
     expect(sets).to.have.lengthOf(2)
     expect(sets[0]).to.deep.equal({
       key: 'productId',


### PR DESCRIPTION
## Summary

On a BMV battery monitor, `TTG` (time-to-go) is `-1` when the battery is not discharging (time-to-go is infinite). The converter scaled raw minutes by 60, so `-1` became `-60` seconds and dashboards showed a nonsensical negative time.

This treats `-1` as an explicit `null` so Signal K clears the path, matching the Venus plugin's behaviour for the same case.

## Approach

`null` and "skip" were previously the same thing in the converter pipeline. To emit a clearing `null` without clearing every other skipped field, the contract is now:

- `undefined` -> skip the field (leave any prior value untouched)
- `null` -> store an explicit null (clears the value in Signal K)

Converters that used `null` to mean skip now return `undefined` (the numeric helpers, temperature, AC-output, the `PID` side-effect converter, and the enum decoders). `StoredField.value` and the delta value type widen to allow `null`.

A plain `return null` on `-1` would not be enough: `generateDelta` re-emits the persistent store every block, so a skipped `-1` would keep re-broadcasting the last finite estimate after charging starts. The explicit `null` is what actually clears it (the discharge-to-charge transition is covered by a test).

Clearing-on-null is standard Signal K delta semantics, consistent with the Venus plugin; this repo forwards the delta to `app.handleMessage` unchanged.

## Tests

Written test-first. Added unit coverage for the TTG sentinel (`-1` -> null; `0` and `-2` scale normally; non-numeric -> skip), the parser storing and emitting an explicit null, the discharge-to-charge transition, and an end-to-end null through the `addChunk` pipeline in the noisy-stream integration test. Full suite green (99 passing), typecheck/prettier/build clean, coverage 100% lines on the changed source.

Closes #56