### PR TITLE
fix: distinct $source per VE.Direct connection

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -379,7 +379,11 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
         {
           source: {
             label: '@signalk/vedirect-serial-usb',
-            type: 'VE.direct'
+            type: 'VE.direct',
+            // Per-connection discriminator. The host combines it with the
+            // provider id into a distinct `$source` (e.g. vedirect-signalk.0),
+            // so several VE.Direct devices remain individually addressable.
+            src: String(connectionIndex)
           },
           timestamp: new Date().toISOString(),
           values

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,14 @@ import type {
   VEDirectConnection
 } from './types'
 
+// The plugin id doubles as the Signal K source label. It is passed to
+// app.handleMessage() as the provider id, and the server uses that as the
+// `$source` prefix for every value the plugin emits, because the delta's own
+// package-name label (`@signalk/...`) is not a charset-valid source id. The
+// parser stamps a per-connection `src` onto each delta, so the host derives a
+// distinct source per device: `vedirect-signalk.0`, `vedirect-signalk.1`, ...
+const PLUGIN_ID = 'vedirect-signalk'
+
 const createPlugin = function (app: SignalKApp): Plugin {
   const parser: VEDirectParser[] = []
   let shaddow: PluginOptions | null = null
@@ -30,7 +38,7 @@ const createPlugin = function (app: SignalKApp): Plugin {
     parser[connectionIndex] = instance
 
     instance.on('delta', (delta: SKDelta) => {
-      app.handleMessage('pluginId', delta)
+      app.handleMessage(PLUGIN_ID, delta)
     })
 
     if (conn.device === 'Serial') {
@@ -83,7 +91,7 @@ const createPlugin = function (app: SignalKApp): Plugin {
   }
 
   const plugin: Plugin = {
-    id: 'vedirect-signalk',
+    id: PLUGIN_ID,
     name: 'VE.Direct to Signal K',
     description: 'VE.Direct to Signal K',
 

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -41,7 +41,10 @@ class VEDirect extends EventEmitter {
 
     this.app = {
       handleMessage: (kind: string, data: SKDelta) => {
-        if (kind === 'pluginId') {
+        // The plugin posts its parsed deltas under its own id; re-emit those as
+        // `delta` events. Anything else the host might receive passes through
+        // on a channel named for its kind.
+        if (kind === this.plugin.id) {
           this.emit('delta', data)
           return
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export interface Plugin {
 export interface SKDelta {
   context: string
   updates: Array<{
-    source: { label: string; type: string }
+    source: { label: string; type: string; src: string }
     timestamp: string
     values: Array<{ path: string; value: number | string }>
   }>

--- a/test/integration/realCapture.ts
+++ b/test/integration/realCapture.ts
@@ -64,7 +64,8 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
     expect(delta.updates).to.have.lengthOf(1)
     expect(delta.updates[0]!.source).to.deep.equal({
       label: '@signalk/vedirect-serial-usb',
-      type: 'VE.direct'
+      type: 'VE.direct',
+      src: '0'
     })
   })
 

--- a/test/unit/Parser.ts
+++ b/test/unit/Parser.ts
@@ -502,11 +502,27 @@ describe('VEDirectParser - generateDelta()', () => {
     expect(deltas[0]!.context).to.equal('vessels.self')
     expect(update.source).to.deep.equal({
       label: '@signalk/vedirect-serial-usb',
-      type: 'VE.direct'
+      type: 'VE.direct',
+      src: '0'
     })
     expect(new Date(update.timestamp).toISOString()).to.equal(update.timestamp)
     expect(update.values).to.deep.equal([
       { path: 'electrical.batteries.House.voltage', value: 12.34 }
+    ])
+  })
+
+  it('stamps the source with the connection index so devices stay distinct', () => {
+    const parser = new VEDirectParser(CONNECTION)
+    const deltas: SKDelta[] = []
+    parser.on('delta', (d: SKDelta) => deltas.push(d))
+
+    parser.parse('V\t12340')
+    parser.generateDelta(0)
+    parser.generateDelta(1)
+
+    expect(deltas.map((d) => d.updates[0]!.source.src)).to.deep.equal([
+      '0',
+      '1'
     ])
   })
 })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -3,8 +3,8 @@
  *
  * The three transports are replaced (via the require cache) with spies, so the
  * factory's wiring is observed without opening any port: which transport each
- * configured device starts, that parsed deltas reach the host as `pluginId`
- * messages, that the legacy flat config is translated, and that stop() tears
+ * configured device starts, that parsed deltas reach the host under the plugin
+ * id, that the legacy flat config is translated, and that stop() tears
  * each connection down.
  */
 import { expect } from 'chai'
@@ -167,7 +167,7 @@ describe('plugin factory', () => {
     ])
   })
 
-  it('forwards a parsed delta to the host as a pluginId message', () => {
+  it('forwards a parsed delta to the host under the plugin id', () => {
     const { plugin, stubs, messages } = loadPlugin()
     plugin.start({ vedirect: [conn({ device: 'UDP' })] })
 
@@ -177,7 +177,7 @@ describe('plugin factory', () => {
     parser.addChunk(Buffer.from('\nV\t12340\nChecksum\t1'), grabbed!.index)
 
     expect(messages).to.have.lengthOf(1)
-    expect(messages[0]!.id).to.equal('pluginId')
+    expect(messages[0]!.id).to.equal('vedirect-signalk')
     expect(messages[0]!.delta.context).to.equal('vessels.self')
   })
 

--- a/test/unit/standalone.ts
+++ b/test/unit/standalone.ts
@@ -74,7 +74,7 @@ describe('standalone wrapper', () => {
     ve.stop()
   })
 
-  it('re-emits non-pluginId host messages under their own channel', () => {
+  it('re-emits other host messages under their own channel', () => {
     const transports = makeTransportStubs()
     const VEDirect = loadStandalone(transports.stubs)
     const ve = new VEDirect()


### PR DESCRIPTION
## Summary

Every emitted value previously shared a single `$source` ending in `.XX`, and the provider id passed to `handleMessage` was the placeholder string `'pluginId'`. So the source surfaced as `pluginId.XX`: the label was meaningless and, more importantly, every VE.Direct connection collapsed onto the same source, leaving SignalK unable to tell two devices apart or apply per-source priorities on shared paths.

This passes the real plugin id to `handleMessage` and stamps a per-connection `src` (the connection index) onto each delta, so the server derives a distinct source per device: `vedirect-signalk.0`, `vedirect-signalk.1`, ...

The standalone library wrapper now keys its `delta` re-emit on the actual plugin id rather than the same placeholder.

Re-implements the idea behind #63 against the current TypeScript codebase; that PR targeted the pre-TS layout and no longer applies cleanly.

## Breaking change

The `$source` for emitted values changes from `pluginId.XX` to `vedirect-signalk.<connection-index>`. Installations with source-priority rules keyed on the old value must update them. Worth a changelog note on the next release.

## Testing

- `npm run typecheck` clean
- `npm test` — 96 passing
- `prettier --check .` clean
- Coverage holds (changed files at 100% lines)
- Added a unit test asserting connections 0 and 1 produce distinct `src`
