### PR TITLE
feat: route solar charger V/I under electrical.solar

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -404,12 +404,22 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
     if (!field?.path) {
       return null
     }
-    if (field.unitId === undefined) {
-      return field.path
-    }
 
     const conn = this.options.vedirect?.[connectionIndex]
-    return field.path.replace('*', this.resolveUnitId(field.unitId, conn))
+
+    // On a solar charger, VE.Direct's V/I labels describe the charger's DC
+    // output rather than a battery, so those fields are reported under
+    // electrical.solar (via the field's solarCharger override) to avoid
+    // clashing with a battery monitor on the same bank.
+    const override =
+      conn?.deviceType === 'Solar charger' ? field.solarCharger : undefined
+    const path = override?.path ?? field.path
+    const unitId = override?.unitId ?? field.unitId
+
+    if (unitId === undefined) {
+      return path
+    }
+    return path.replace('*', this.resolveUnitId(unitId, conn))
   }
 
   /**

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -51,6 +51,10 @@ const fields: FieldMap = {
     name: 'mainBattVoltage',
     path: 'electrical.batteries.*.voltage',
     unitId: 'mainBatt',
+    // On a solar charger, V and I describe the charger's DC output rather than a
+    // battery, so they are reported under electrical.solar to avoid clashing
+    // with a battery monitor on the same bank.
+    solarCharger: { path: 'electrical.solar.*.voltage', unitId: 'solar' },
     value: common.mV,
     units: 'V',
     type: 'metric'
@@ -110,6 +114,9 @@ const fields: FieldMap = {
     name: 'batteryCurrent',
     path: 'electrical.batteries.*.current',
     unitId: 'mainBatt',
+    // Like V, on a solar charger this is the charger's DC output and is reported
+    // under electrical.solar rather than electrical.batteries.
+    solarCharger: { path: 'electrical.solar.*.current', unitId: 'solar' },
     value: common.mA,
     units: 'A',
     type: 'metric'

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,8 @@ const createPlugin = function (app: SignalKApp): Plugin {
       mainBatt: options.mainBatt ?? 'House',
       auxBatt: options.auxBatt ?? 'Starter',
       bmv: options.bmv ?? 'bmv',
-      solar: options.solar ?? 'Main'
+      solar: options.solar ?? 'Main',
+      deviceType: options.deviceType
     }
 
     if (options.device) {
@@ -163,6 +164,14 @@ const createPlugin = function (app: SignalKApp): Plugin {
                 title: 'Port',
                 description: 'Serial: ignored, UDP/TCP: port',
                 default: 7878
+              },
+              deviceType: {
+                type: 'string',
+                title: 'Device type',
+                description:
+                  'Battery monitor keeps V/I under electrical.batteries; Solar charger (MPPT) routes V/I under electrical.solar to avoid clashing with a battery monitor on the same bank',
+                default: 'Battery monitor',
+                enum: ['Battery monitor', 'Solar charger']
               },
               ignoreChecksum: {
                 type: 'boolean',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,20 @@
  *  shim and the network modules use the same shape. */
 export type DebugFn = (message: string) => void
 
+/**
+ * What kind of Victron device a connection talks to. VE.Direct reuses the
+ * `V`/`I` labels for both battery monitors and solar chargers, so the device
+ * type decides where those readings land (see `Field.solarCharger`). Treated as
+ * a battery monitor when unset, which preserves the historical paths.
+ */
+export type DeviceType = 'Battery monitor' | 'Solar charger'
+
 /** One VE.Direct connection as configured in the plugin schema. */
 export interface VEDirectConnection {
   device: 'Serial' | 'UDP' | 'TCP'
   connection: string
   port: number
+  deviceType?: DeviceType
   ignoreChecksum: boolean
   mainBatt: string
   auxBatt: string
@@ -44,6 +53,7 @@ export interface PluginOptions {
   auxBatt?: string
   bmv?: string
   solar?: string
+  deviceType?: DeviceType
 }
 
 /** Flat single-connection configuration accepted by the standalone library
@@ -60,6 +70,7 @@ export interface VEDirectConfig {
   auxBatt?: string
   bmv?: string
   solar?: string
+  deviceType?: DeviceType
 }
 
 /** Minimal structural type for the `app` the signalk-server host passes to
@@ -122,6 +133,14 @@ export interface Field {
   name: string
   path?: string
   unitId?: UnitId
+  /**
+   * Alternative path and unit used when the connection is a solar charger.
+   * VE.Direct sends battery-monitor and charger data under the same labels, but
+   * a charger's reading describes its DC output, which belongs under
+   * electrical.solar, not electrical.batteries where it would clash with a
+   * monitor on the same bank.
+   */
+  solarCharger?: { path: string; unitId: UnitId }
   units?: string
   type?: FieldType
   value?: FieldValue

--- a/test/integration/realCapture.ts
+++ b/test/integration/realCapture.ts
@@ -13,9 +13,9 @@
  * robustness over a noisy stream rather than exact values.
  */
 import { expect } from 'chai'
-import { runBlock, toBlock } from '../helpers/capture'
+import { runBlock, toBlock, STANDARD_OPTIONS } from '../helpers/capture'
 import type { VEDirectParser } from '../../src/Parser'
-import type { SKDelta } from '../../src/types'
+import type { PluginOptions, SKDelta } from '../../src/types'
 
 // One VE.Direct frame as label/value pairs. The Checksum value is a placeholder
 // since verification is disabled by the standard (ignoreChecksum) config.
@@ -40,13 +40,20 @@ const CAPTURE: ReadonlyArray<readonly [string, string]> = [
   ['Checksum', '?']
 ]
 
+// This capture is a solar charger, so configure the connection as one: its V/I
+// (the charger's DC output) then land under electrical.solar instead of
+// electrical.batteries, where they would clash with a battery monitor.
+const MPPT_OPTIONS: PluginOptions = {
+  vedirect: [{ ...STANDARD_OPTIONS.vedirect![0]!, deviceType: 'Solar charger' }]
+}
+
 describe('integration: real BlueSolar MPPT 75/10 capture', () => {
   let parser: VEDirectParser
   let delta: SKDelta
   let values: Array<{ path: string; value: number | string | null }>
 
   before(() => {
-    const run = runBlock(toBlock(CAPTURE))
+    const run = runBlock(toBlock(CAPTURE), MPPT_OPTIONS)
     expect(run.deltas, 'one delta per block').to.have.lengthOf(1)
     parser = run.parser
     delta = run.deltas[0]!
@@ -75,9 +82,10 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
     // undefined (no error) so it is skipped.
     expect(values).to.have.lengthOf(12)
 
-    // Battery (mainBatt -> "House"): mV and mA conversions.
-    expect(valueAt('electrical.batteries.House.voltage')).to.equal(14.99) // V 14990 mV
-    expect(valueAt('electrical.batteries.House.current')).to.equal(2.77) // I 2770 mA
+    // This connection is a solar charger, so V and I describe its DC output and
+    // are reported under electrical.solar rather than electrical.batteries.
+    expect(valueAt('electrical.solar.Main.voltage')).to.equal(14.99) // V 14990 mV -> solar
+    expect(valueAt('electrical.solar.Main.current')).to.equal(2.77) // I 2770 mA -> solar
     expect(valueAt('electrical.charger.House.chargingMode')).to.equal(
       'absorption'
     ) // CS 4

--- a/test/unit/Parser.ts
+++ b/test/unit/Parser.ts
@@ -470,6 +470,30 @@ describe('VEDirectParser - getPath()', () => {
     expect(parser.getPath('serialNumber', 0)).to.equal(null)
     expect(parser.getPath('noSuchField', 0)).to.equal(null)
   })
+
+  it('routes a solar charger current under electrical.solar', () => {
+    const mppt = new VEDirectParser({
+      vedirect: [{ ...CONNECTION.vedirect![0]!, deviceType: 'Solar charger' }]
+    })
+    expect(mppt.getPath('batteryCurrent', 0)).to.equal(
+      'electrical.solar.Main.current'
+    )
+  })
+
+  it('routes a solar charger voltage under electrical.solar', () => {
+    const mppt = new VEDirectParser({
+      vedirect: [{ ...CONNECTION.vedirect![0]!, deviceType: 'Solar charger' }]
+    })
+    expect(mppt.getPath('mainBattVoltage', 0)).to.equal(
+      'electrical.solar.Main.voltage'
+    )
+  })
+
+  it('keeps current on the battery path for a battery monitor', () => {
+    expect(parser.getPath('batteryCurrent', 0)).to.equal(
+      'electrical.batteries.House.current'
+    )
+  })
 })
 
 describe('VEDirectParser - generateDelta()', () => {

--- a/test/unit/fields.ts
+++ b/test/unit/fields.ts
@@ -406,4 +406,15 @@ describe('fields - static table', () => {
       expect(rowOf(field!), `field ${key}`).to.deep.equal(expected)
     }
   })
+
+  it('routes battery voltage and current to electrical.solar for a solar charger', () => {
+    expect(fields.V!.solarCharger).to.deep.equal({
+      path: 'electrical.solar.*.voltage',
+      unitId: 'solar'
+    })
+    expect(fields.I!.solarCharger).to.deep.equal({
+      path: 'electrical.solar.*.current',
+      unitId: 'solar'
+    })
+  })
 })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -142,9 +142,17 @@ describe('plugin factory', () => {
     expect(plugin.id).to.equal('vedirect-signalk')
     expect(plugin.name).to.equal('VE.Direct to Signal K')
     const schema = plugin.schema as {
-      properties: { vedirect: { type: string } }
+      properties: {
+        vedirect: {
+          type: string
+          items: { properties: { deviceType: { enum: string[] } } }
+        }
+      }
     }
     expect(schema.properties.vedirect.type).to.equal('array')
+    expect(
+      schema.properties.vedirect.items.properties.deviceType.enum
+    ).to.deep.equal(['Battery monitor', 'Solar charger'])
   })
 
   it('starts the matching transport for each configured device', () => {


### PR DESCRIPTION
## Summary

VE.Direct reuses the `V`/`I` labels for both battery monitors and solar chargers, but on a charger they describe its DC output rather than a battery. Reporting an MPPT's V/I under `electrical.batteries.*` is therefore wrong, and collides with a battery monitor on the same bank.

This adds a per-connection **Device type** (`Battery monitor` | `Solar charger`). A solar charger routes `V` and `I` to `electrical.solar.<name>.voltage` / `.current` (both valid spec paths via `dcQualities`) through a declarative `solarCharger` override on the field. Everything else is unchanged.

Default is `Battery monitor`, so existing installations keep their current paths until they opt in — no silent data migration.

Reworks the path-routing idea from #62 against the current TypeScript codebase. I deliberately dropped #62's other change (PPV → panelCurrent): `electrical.solar.*.panelPower` is in the Signal K spec, so that field is kept as-is.

Independent of #83 (already merged); this only touches path routing, not source identity.

## Testing

- `npm run typecheck`, `npm test` (104 passing), `prettier --check .`
- The real BlueSolar MPPT integration capture is now configured as a solar charger and asserts `V`/`I` under `electrical.solar.Main.*`
- Added `getPath` unit tests for solar-charger and battery-monitor routing, and a field-table assertion for the override
