### PR TITLE
fix: emit $source ref instead of an NMEA2000 src field

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -23,6 +23,7 @@ import type {
   UnitId,
   VEDirectConnection
 } from './types'
+import { PLUGIN_ID } from './constants'
 
 /** Parser configuration after merging caller options with defaults. */
 interface ParserOptions extends PluginOptions {
@@ -380,14 +381,14 @@ export class VEDirectParser extends EventEmitter implements FieldContext {
       context: 'vessels.self',
       updates: [
         {
-          source: {
-            label: '@signalk/vedirect-serial-usb',
-            type: 'VE.direct',
-            // Per-connection discriminator. The host combines it with the
-            // provider id into a distinct `$source` (e.g. vedirect-signalk.0),
-            // so several VE.Direct devices remain individually addressable.
-            src: String(connectionIndex)
-          },
+          // Set the Signal K source ref as a bare string rather than a
+          // structured `source` object. signalk-server reads any `source.src`
+          // as an NMEA 2000 device address, so a VE.Direct delta carrying one
+          // would corrupt the server's `sources` tree with bogus
+          // `sources.*.n2k.pgns` nodes. A plain `$source` sidesteps that while
+          // keeping each connection individually addressable:
+          // `vedirect-signalk.0`, `vedirect-signalk.1`, ...
+          $source: `${PLUGIN_ID}.${connectionIndex}`,
           timestamp: new Date().toISOString(),
           values
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Plugin-wide constants.
+ */
+
+// The plugin id. signalk-server receives it as the provider id (the first
+// argument to app.handleMessage), and the parser reuses it to namespace the
+// per-connection Signal K source ref it stamps on each delta
+// (`vedirect-signalk.0`, `vedirect-signalk.1`, ...). Both src/index.ts and
+// src/Parser.ts need it; index.ts uses `export =` and so cannot re-export a
+// named const, hence this shared module keeps the two from drifting apart.
+export const PLUGIN_ID = 'vedirect-signalk'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,14 +17,7 @@ import type {
   SKDelta,
   VEDirectConnection
 } from './types'
-
-// The plugin id doubles as the Signal K source label. It is passed to
-// app.handleMessage() as the provider id, and the server uses that as the
-// `$source` prefix for every value the plugin emits, because the delta's own
-// package-name label (`@signalk/...`) is not a charset-valid source id. The
-// parser stamps a per-connection `src` onto each delta, so the host derives a
-// distinct source per device: `vedirect-signalk.0`, `vedirect-signalk.1`, ...
-const PLUGIN_ID = 'vedirect-signalk'
+import { PLUGIN_ID } from './constants'
 
 const createPlugin = function (app: SignalKApp): Plugin {
   const parser: VEDirectParser[] = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,11 +90,15 @@ export interface Plugin {
   schema: object
 }
 
-/** A Signal K delta message emitted for a parsed VE.Direct block. */
+/** A Signal K delta message emitted for a parsed VE.Direct block.
+ *
+ * The source is carried as a `$source` ref string (`vedirect-signalk.<index>`)
+ * rather than a structured `source` object: a `source.src` field would make
+ * signalk-server misclassify the stream as NMEA 2000. See src/Parser.ts. */
 export interface SKDelta {
   context: string
   updates: Array<{
-    source: { label: string; type: string; src: string }
+    $source: string
     timestamp: string
     values: Array<{ path: string; value: number | string | null }>
   }>

--- a/test/integration/realCapture.ts
+++ b/test/integration/realCapture.ts
@@ -66,14 +66,10 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
     return found!.value
   }
 
-  it('emits a single self-context delta tagged as a VE.direct source', () => {
+  it('emits a single self-context delta with a per-connection $source', () => {
     expect(delta.context).to.equal('vessels.self')
     expect(delta.updates).to.have.lengthOf(1)
-    expect(delta.updates[0]!.source).to.deep.equal({
-      label: '@signalk/vedirect-serial-usb',
-      type: 'VE.direct',
-      src: '0'
-    })
+    expect(delta.updates[0]!.$source).to.equal('vedirect-signalk.0')
   })
 
   it('decodes every path-mapped field with the correct unit conversion', () => {

--- a/test/integration/sampleStream.ts
+++ b/test/integration/sampleStream.ts
@@ -122,7 +122,7 @@ describe('integration: noisy BMV-702 stream', () => {
       expect(delta.context).to.equal('vessels.self')
       expect(delta.updates).to.have.lengthOf(1)
       const update = delta.updates[0]!
-      expect(update.source.type).to.equal('VE.direct')
+      expect(update.$source).to.equal('vedirect-signalk.0')
       expect(update.values.length).to.be.greaterThan(0)
       for (const v of update.values) {
         expect(v.path, 'every value has a non-empty path')

--- a/test/unit/Parser.ts
+++ b/test/unit/Parser.ts
@@ -524,18 +524,14 @@ describe('VEDirectParser - generateDelta()', () => {
     expect(deltas).to.have.lengthOf(1)
     const update = deltas[0]!.updates[0]!
     expect(deltas[0]!.context).to.equal('vessels.self')
-    expect(update.source).to.deep.equal({
-      label: '@signalk/vedirect-serial-usb',
-      type: 'VE.direct',
-      src: '0'
-    })
+    expect(update.$source).to.equal('vedirect-signalk.0')
     expect(new Date(update.timestamp).toISOString()).to.equal(update.timestamp)
     expect(update.values).to.deep.equal([
       { path: 'electrical.batteries.House.voltage', value: 12.34 }
     ])
   })
 
-  it('stamps the source with the connection index so devices stay distinct', () => {
+  it('stamps a per-connection $source so devices stay distinct', () => {
     const parser = new VEDirectParser(CONNECTION)
     const deltas: SKDelta[] = []
     parser.on('delta', (d: SKDelta) => deltas.push(d))
@@ -544,9 +540,9 @@ describe('VEDirectParser - generateDelta()', () => {
     parser.generateDelta(0)
     parser.generateDelta(1)
 
-    expect(deltas.map((d) => d.updates[0]!.source.src)).to.deep.equal([
-      '0',
-      '1'
+    expect(deltas.map((d) => d.updates[0]!.$source)).to.deep.equal([
+      'vedirect-signalk.0',
+      'vedirect-signalk.1'
     ])
   })
 })


### PR DESCRIPTION
## Summary

[PR #83](https://github.com/SignalK/vedirect-serial-usb/pull/83) gave each VE.Direct connection a distinct `$source` by stamping a `src` field onto the delta's `source` object. signalk-server treats any `source.src` as an **NMEA 2000 device address**: both `getSourceId` (`packages/server-api/src/sourceutil.ts`) and `FullSignalK.updateSource` (`packages/server-api/src/fullsignalk.ts`) route such a source through the N2000 handler, which writes `sources.<label>.<src>.n2k.pgns[<pgn>]` into the full model. A VE.Direct delta has no `pgn`, so the server inserts a bogus `pgns: { "undefined": <timestamp> }` node. This surfaces as corrupt `n2k`/`pgns` entries in the Data Browser source tree, [reported on #83](https://github.com/SignalK/vedirect-serial-usb/pull/83#issuecomment-4643693780).

This sets `$source` directly as `vedirect-signalk.<index>` and drops the structured `source` object. With no `source` object present, the server never calls `updateSource`, and builds a clean `sources.vedirect-signalk.<index>` node from the `$source` string (`updateDollarSource`) instead.

The emitted `$source` string is **unchanged** (`vedirect-signalk.0`, `vedirect-signalk.1`, ...), so any source-priority config keyed on it keeps working; only the spurious n2k/pgns pollution is removed. No new migration beyond #83.

## Changes
- `src/Parser.ts`: emit `$source: vedirect-signalk.<index>` instead of `source: { label, type, src }`.
- `src/types.ts`: `SKDelta` update carries `$source: string`.
- `src/constants.ts` (new): shared `PLUGIN_ID` so the provider id and the source-ref prefix cannot drift apart (`index.ts` uses `export =` and cannot re-export a named const).
- Tests updated to assert `$source`.

## Testing
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 104 passing
- `npm run prettier:check` — clean