### PR TITLE
feat: control the BMV relay via a PUT handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ Set up the appropriate device on the settings page of this plugin in the Signal 
 
 - Give each device unique SK paths
 
+## BMV relay control
+
+For BMV-7xx battery monitors on a **serial** connection, the built-in relay is
+exposed as a writable Signal K path so other plugins can switch it:
+
+```
+electrical.batteries.<bmv>.relay
+```
+
+where `<bmv>` is the BMV name configured for the connection. Send a PUT request
+with a value of `1`/`true` to close the relay or `0`/`false` to open it. The
+plugin reports an error if the value is out of range or the serial port is not
+open, rather than silently doing nothing.
+
+The writable path exists only for a serial connection whose **device type is a
+battery monitor** (not a solar charger) and that has a **BMV name** configured;
+without a name there is nothing to anchor the path to, so no writable path is
+registered. A successful response means the command was written to the port, not
+that the relay is confirmed switched: the BMV sends no acknowledgement, and it
+acts on the command only when its relay is set to **remote control** on the BMV
+itself. Relay control is only available over serial, as it depends on writing
+back to the VE.Direct port.
+
 ## Usage as a library
 
 It's possible to use this plugin as a library, in other Node.js code. This feature simply wraps the plugin in an easy-to-consume manner, so functionality is identical. Example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,15 +13,136 @@ import { VEDirectParser } from './Parser'
 import type {
   Plugin,
   PluginOptions,
+  PutHandler,
   SignalKApp,
   SKDelta,
   VEDirectConnection
 } from './types'
 import { PLUGIN_ID } from './constants'
 
+// VE.Direct HEX "Set" frames toggling the BMV-7xx built-in relay (register
+// 0x034E), exposing it as a writable Signal K switch for other plugins.
+//
+//   :  8    4E03    00     VV   CC \n
+//   |  Set  reg LE  flags  val  checksum
+//
+// CC is chosen so (0x08 + every payload byte) & 0xFF == 0x55 (VE.Direct HEX
+// checksum): on -> val 0x01 -> :84E030001FB,  off -> val 0x00 -> :84E030000FC.
+// The BMV only acts on these once its relay is set to remote control.
+const RELAY_ON = ':84E030001FB\n'
+const RELAY_OFF = ':84E030000FC\n'
+
+// Maps a Signal K relay PUT value to its VE.Direct command. Accepts the numeric
+// 1/0 the relay state is published as (see the RELAY field in src/fields.ts) and
+// boolean true/false for convenience. Returns null for any out-of-range value so
+// the handler can reject it.
+function relayCommand(value: unknown): string | null {
+  if (value === 1 || value === true) {
+    return RELAY_ON
+  }
+  if (value === 0 || value === false) {
+    return RELAY_OFF
+  }
+  return null
+}
+
 const createPlugin = function (app: SignalKApp): Plugin {
   const parser: VEDirectParser[] = []
+  // Unregister callbacks for the relay PUT handlers, indexed by connection like
+  // `parser`, so stop() can tear each one down.
+  const putUnregister: Array<() => void> = []
+  // Relay paths already claimed by a registered handler. Two serial connections
+  // configured with the same BMV name resolve to the same path; the host keeps
+  // only one handler, so a PUT could drive the wrong port. The duplicate is
+  // refused instead. Cleared on stop().
+  const registeredRelayPaths = new Set<string>()
   let shaddow: PluginOptions | null = null
+
+  // Builds the PUT handler for one serial connection's BMV relay. It writes the
+  // matching VE.Direct HEX command and reports failure (rather than a false 200)
+  // when the value is out of range or the serial port is not open. A 200 means
+  // the frame was written to the port, not that the relay switched: the BMV sends
+  // no acknowledgement and acts only when its relay is in remote control, so the
+  // reply says "sent", not "confirmed". Each outcome is logged so a command that
+  // looks accepted but changes nothing is still diagnosable from the plugin log.
+  function relayPutHandler(connectionIndex: number): PutHandler {
+    return (_context, path, value) => {
+      const command = relayCommand(value)
+      if (command === null) {
+        app.debug(
+          `Relay PUT on ${path} rejected: ${JSON.stringify(value)} is not 0/1 or true/false`
+        )
+        return {
+          state: 'COMPLETED',
+          statusCode: 400,
+          message: `Invalid relay value ${JSON.stringify(value)} for ${path}; expected 0/1 or true/false`
+        }
+      }
+
+      const desired = command === RELAY_ON ? 'on' : 'off'
+
+      if (!serial.write(command, connectionIndex)) {
+        app.debug(
+          `Relay PUT on ${path} ignored: serial connection ${connectionIndex} is not open`
+        )
+        return {
+          state: 'COMPLETED',
+          statusCode: 503,
+          message: `Serial connection ${connectionIndex} is not open; relay unchanged`
+        }
+      }
+
+      app.debug(
+        `Relay PUT on ${path}: ${desired} command sent to serial connection ${connectionIndex} (the BMV applies it only when its relay is in remote control)`
+      )
+      return {
+        state: 'COMPLETED',
+        statusCode: 200,
+        message: `Relay ${desired} command sent; takes effect only when the BMV relay is set to remote control`
+      }
+    }
+  }
+
+  // Exposes the BMV relay as a writable Signal K path for one serial connection,
+  // anchored on the configured BMV name (matching the RELAY read field's path,
+  // electrical.batteries.<bmv>). The relay belongs to the BMV-7xx, so it is
+  // registered only for battery monitors (the default when deviceType is unset),
+  // never for a solar charger, and only when a BMV name is configured to anchor
+  // the path. The skipped cases are logged rather than silent: the RELAY field
+  // still publishes the relay state, so a writable path that is quietly absent
+  // would be a mystery to whoever tries to PUT to it.
+  function registerRelayHandler(
+    conn: VEDirectConnection,
+    connectionIndex: number
+  ): void {
+    if (conn.deviceType === 'Solar charger') {
+      app.debug(
+        `Serial connection ${connectionIndex} is a solar charger, not a BMV; relay control disabled`
+      )
+      return
+    }
+    if (!conn.bmv) {
+      app.debug(
+        `Serial connection ${connectionIndex} has no BMV name; relay control disabled`
+      )
+      return
+    }
+
+    const path = `electrical.batteries.${conn.bmv}.relay`
+    if (registeredRelayPaths.has(path)) {
+      app.debug(
+        `Relay path ${path} is already registered by another connection; relay control disabled for serial connection ${connectionIndex}`
+      )
+      return
+    }
+
+    registeredRelayPaths.add(path)
+    putUnregister[connectionIndex] = app.registerPutHandler(
+      'vessels.self',
+      path,
+      relayPutHandler(connectionIndex)
+    )
+  }
 
   function startConnection(
     conn: VEDirectConnection,
@@ -36,6 +157,7 @@ const createPlugin = function (app: SignalKApp): Plugin {
 
     if (conn.device === 'Serial') {
       serial.open(conn.connection, parser, app.debug, connectionIndex)
+      registerRelayHandler(conn, connectionIndex)
     } else if (conn.device === 'UDP') {
       udp.listen(conn.port, parser, app.debug, connectionIndex)
     } else if (conn.device === 'TCP') {
@@ -115,6 +237,8 @@ const createPlugin = function (app: SignalKApp): Plugin {
         shaddow.vedirect.forEach((conn, connectionIndex) => {
           parser[connectionIndex]?.removeAllListeners()
           delete parser[connectionIndex]
+          putUnregister[connectionIndex]?.()
+          delete putUnregister[connectionIndex]
           if (conn.device === 'Serial') {
             serial.close(app.debug, connectionIndex)
           } else if (conn.device === 'UDP') {
@@ -123,6 +247,7 @@ const createPlugin = function (app: SignalKApp): Plugin {
             tcp.close(app.debug, connectionIndex)
           }
         })
+        registeredRelayPaths.clear()
       }
 
       shaddow = null

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -75,6 +75,34 @@ export function close(debug: DebugFn, connectionIndex: number): void {
   debug('Serial port closed')
 }
 
+/**
+ * Writes a raw command to a connection's serial port, used for outbound
+ * VE.Direct HEX control frames (e.g. setting the BMV relay). Returns true only
+ * when the port is open and the write was issued; false when no open port
+ * exists for the index (including the gap while an unexpectedly-closed port
+ * awaits reconnect) so the caller can report failure instead of assuming the
+ * command reached the device.
+ */
+export function write(message: string, connectionIndex: number): boolean {
+  const sp = port[connectionIndex]
+  if (sp === undefined || !sp.isOpen) {
+    return false
+  }
+
+  try {
+    sp.write(message)
+    // True means the write was issued, not flushed: serialport surfaces most
+    // write failures asynchronously via the 'error' event, which this
+    // synchronous boolean cannot reflect. The isOpen guard above covers the
+    // common "port not open" case, which is the failure mode worth reporting.
+    return true
+  } catch {
+    // The port can still drop between the isOpen check and the write; treat
+    // that as a failed write rather than a thrown error to the PUT requester.
+    return false
+  }
+}
+
 // Cancels any pending reconnect and closes the active port for a slot. The slot
 // is cleared before close() so the port's 'close' handler does not schedule a
 // reconnect for a deliberate teardown.

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -51,6 +51,10 @@ class VEDirect extends EventEmitter {
         this.emit(kind, data)
       },
       debug: (msg: string) => this.debug(msg),
+      // The standalone library has no PUT transport, so relay handler
+      // registrations are accepted and dropped; the returned no-op unregister
+      // keeps start()/stop() symmetric with the server host.
+      registerPutHandler: () => () => {},
       options
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,11 +73,45 @@ export interface VEDirectConfig {
   deviceType?: DeviceType
 }
 
+/**
+ * Result of a Signal K PUT action. A handler returns `COMPLETED` (with an
+ * HTTP-like `statusCode`) to answer synchronously, or `PENDING` when it will
+ * call the async callback later. This plugin only answers synchronously.
+ */
+export interface PutResult {
+  state: 'COMPLETED' | 'PENDING'
+  statusCode?: number
+  message?: string
+}
+
+/**
+ * Handler for a PUT request on a registered context/path. `value` is whatever
+ * the requester sent (hence `unknown`; the handler narrows it). The trailing
+ * callback is for `PENDING` async replies and is unused here.
+ */
+export type PutHandler = (
+  context: string,
+  path: string,
+  value: unknown,
+  callback: (result: PutResult) => void
+) => PutResult | void
+
 /** Minimal structural type for the `app` the signalk-server host passes to
  *  the plugin factory. */
 export interface SignalKApp {
   handleMessage(id: string, delta: SKDelta): void
   debug: DebugFn
+  /**
+   * Registers a handler for PUT requests on `context`/`path`. Returns a
+   * function that unregisters it again, which the plugin calls on `stop()` so a
+   * config reload does not leave a stale handler writing to a closed port.
+   */
+  registerPutHandler(
+    context: string,
+    path: string,
+    handler: PutHandler,
+    source?: string
+  ): () => void
 }
 
 /** Shape of the plugin object returned to the signalk-server host. */

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -12,6 +12,8 @@ import { requireFresh } from '../helpers/moduleStub'
 import type {
   Plugin,
   PluginOptions,
+  PutHandler,
+  PutResult,
   SignalKApp,
   SKDelta,
   VEDirectConnection
@@ -28,22 +30,28 @@ function makeStubs(): {
   tcp: Record<string, unknown>
   calls: {
     serialOpen: Array<{ device: string; items: number }>
+    serialWrite: Array<{ message: string; items: number }>
     udpListen: Array<{ port: number; items: number }>
     tcpConnect: Array<{ host: string; port: number; items: number }>
     serialClose: number[]
     udpClose: number[]
     tcpClose: number[]
   }
+  // Controls what the serial.write spy returns, so a test can simulate a port
+  // that is open (true) or not open (false).
+  control: { writeReturns: boolean }
   captured: () => { parser: ParserClass[]; index: number } | null
 } {
   const calls = {
     serialOpen: [] as Array<{ device: string; items: number }>,
+    serialWrite: [] as Array<{ message: string; items: number }>,
     udpListen: [] as Array<{ port: number; items: number }>,
     tcpConnect: [] as Array<{ host: string; port: number; items: number }>,
     serialClose: [] as number[],
     udpClose: [] as number[],
     tcpClose: [] as number[]
   }
+  const control = { writeReturns: true }
   let captured: { parser: ParserClass[]; index: number } | null = null
   const grab = (parser: ParserClass[], index: number): void => {
     captured = { parser, index }
@@ -51,6 +59,7 @@ function makeStubs(): {
 
   return {
     calls,
+    control,
     captured: () => captured,
     serial: {
       open: (
@@ -62,7 +71,11 @@ function makeStubs(): {
         calls.serialOpen.push({ device, items })
         grab(parser, items)
       },
-      close: (_d: unknown, items: number) => calls.serialClose.push(items)
+      close: (_d: unknown, items: number) => calls.serialClose.push(items),
+      write: (message: string, items: number) => {
+        calls.serialWrite.push({ message, items })
+        return control.writeReturns
+      }
     },
     udp: {
       listen: (
@@ -92,18 +105,51 @@ function makeStubs(): {
   }
 }
 
+/** A captured PUT registration plus the unregister callback handed back to the
+ *  plugin, so tests can both invoke the handler and assert teardown. */
+interface PutRegistration {
+  context: string
+  path: string
+  handler: PutHandler
+  unregister: () => void
+  unregistered: boolean
+}
+
 function makeApp(): {
   app: SignalKApp
   messages: Array<{ id: string; delta: SKDelta }>
+  debugLogs: string[]
+  puts: PutRegistration[]
 } {
   const messages: Array<{ id: string; delta: SKDelta }> = []
+  const debugLogs: string[] = []
+  const puts: PutRegistration[] = []
   return {
     app: {
       handleMessage: (id: string, delta: SKDelta) =>
         messages.push({ id, delta }),
-      debug: () => {}
+      debug: (msg: string) => debugLogs.push(msg),
+      registerPutHandler: (
+        context: string,
+        path: string,
+        handler: PutHandler
+      ) => {
+        const registration: PutRegistration = {
+          context,
+          path,
+          handler,
+          unregister: () => {
+            registration.unregistered = true
+          },
+          unregistered: false
+        }
+        puts.push(registration)
+        return registration.unregister
+      }
     },
-    messages
+    messages,
+    debugLogs,
+    puts
   }
 }
 
@@ -111,6 +157,8 @@ function loadPlugin(): {
   plugin: Plugin
   stubs: ReturnType<typeof makeStubs>
   messages: Array<{ id: string; delta: SKDelta }>
+  debugLogs: string[]
+  puts: PutRegistration[]
 } {
   const stubs = makeStubs()
   const createPlugin = requireFresh<PluginFactory>('src/index', {
@@ -118,8 +166,8 @@ function loadPlugin(): {
     'src/udp': stubs.udp,
     'src/tcp': stubs.tcp
   })
-  const { app, messages } = makeApp()
-  return { plugin: createPlugin(app), stubs, messages }
+  const { app, messages, debugLogs, puts } = makeApp()
+  return { plugin: createPlugin(app), stubs, messages, debugLogs, puts }
 }
 
 function conn(over: Partial<VEDirectConnection>): VEDirectConnection {
@@ -247,5 +295,250 @@ describe('plugin factory', () => {
     const { plugin, stubs } = loadPlugin()
     expect(() => plugin.stop()).to.not.throw()
     expect(stubs.calls.serialClose).to.have.lengthOf(0)
+  })
+})
+
+describe('relay PUT handler', () => {
+  // Starts a single serial connection and returns the captured registration so
+  // the handler can be invoked directly. bmv defaults to 'bmv' (see conn()), so
+  // the relay path is anchored unless a test overrides it.
+  function startSerial(over: Partial<VEDirectConnection> = {}): {
+    stubs: ReturnType<typeof makeStubs>
+    debugLogs: string[]
+    reg: PutRegistration
+  } {
+    const { plugin, stubs, debugLogs, puts } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({ device: 'Serial', connection: '/dev/ttyUSB0', ...over })
+      ]
+    })
+    expect(puts, 'a relay handler was registered').to.have.lengthOf(1)
+    return { stubs, debugLogs, reg: puts[0]! }
+  }
+
+  it('registers a writable relay on the bmv path for a serial connection', () => {
+    const { reg } = startSerial({ bmv: 'house' })
+    expect(reg.context).to.equal('vessels.self')
+    expect(reg.path).to.equal('electrical.batteries.house.relay')
+  })
+
+  it('registers no relay handler for UDP or TCP connections', () => {
+    const { plugin, puts } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({ device: 'UDP', port: 7878 }),
+        conn({ device: 'TCP', connection: '10.0.0.5', port: 2000 })
+      ]
+    })
+    expect(puts).to.have.lengthOf(0)
+  })
+
+  it('registers no relay handler, and logs, when the bmv name is blank', () => {
+    const { plugin, puts, debugLogs } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({ device: 'Serial', connection: '/dev/ttyUSB0', bmv: '' })
+      ]
+    })
+    expect(puts).to.have.lengthOf(0)
+    expect(debugLogs.some((m) => m.includes('relay control disabled'))).to.be
+      .true
+  })
+
+  it('registers no relay handler when the bmv name is absent', () => {
+    // A config persisted before the bmv field existed deserializes without it.
+    const { plugin, puts } = loadPlugin()
+    const c = conn({ device: 'Serial', connection: '/dev/ttyUSB0' })
+    delete (c as { bmv?: string }).bmv
+    plugin.start({ vedirect: [c] })
+    expect(puts).to.have.lengthOf(0)
+  })
+
+  it('registers no relay handler, and logs, for a solar charger', () => {
+    // The relay lives on the BMV-7xx; a solar charger has no such relay, so even
+    // with a BMV name set it must not expose a writable path that would write
+    // register 0x034E to an MPPT.
+    const { plugin, puts, debugLogs } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({
+          device: 'Serial',
+          connection: '/dev/ttyUSB0',
+          deviceType: 'Solar charger',
+          bmv: 'house'
+        })
+      ]
+    })
+    expect(puts).to.have.lengthOf(0)
+    expect(debugLogs.some((m) => m.includes('solar charger'))).to.be.true
+  })
+
+  it('registers a relay handler for an explicit battery monitor', () => {
+    const { reg } = startSerial({ deviceType: 'Battery monitor', bmv: 'house' })
+    expect(reg.path).to.equal('electrical.batteries.house.relay')
+  })
+
+  it('registers only one relay handler when two serial connections share a bmv name', () => {
+    // Both serial connections resolve to electrical.batteries.bmv.relay; the host
+    // would keep a single handler, so a PUT could drive the wrong port. The second
+    // registration is refused and logged rather than silently shadowing the first.
+    const { plugin, puts, debugLogs } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({ device: 'Serial', connection: '/dev/ttyUSB0', bmv: 'bmv' }),
+        conn({ device: 'Serial', connection: '/dev/ttyUSB1', bmv: 'bmv' })
+      ]
+    })
+    expect(puts).to.have.lengthOf(1)
+    expect(puts[0]!.path).to.equal('electrical.batteries.bmv.relay')
+    expect(debugLogs.some((m) => m.includes('already registered'))).to.be.true
+  })
+
+  it('frees the relay path on stop() so a restart can re-register it', () => {
+    const { plugin, puts } = loadPlugin()
+    const options = {
+      vedirect: [
+        conn({ device: 'Serial', connection: '/dev/ttyUSB0', bmv: 'bmv' })
+      ]
+    }
+    plugin.start(options)
+    plugin.stop()
+    plugin.start(options)
+    // Two registrations across the restart: the second start is not mistaken for
+    // a duplicate, proving stop() released the claimed path.
+    expect(puts).to.have.lengthOf(2)
+    expect(puts[1]!.path).to.equal('electrical.batteries.bmv.relay')
+  })
+
+  it('writes the relay-on command and reports success for value 1', () => {
+    const { stubs, debugLogs, reg } = startSerial()
+    const result = reg.handler(
+      'vessels.self',
+      reg.path,
+      1,
+      () => {}
+    ) as PutResult
+    expect(stubs.calls.serialWrite).to.deep.equal([
+      { message: ':84E030001FB\n', items: 0 }
+    ])
+    expect(result.state).to.equal('COMPLETED')
+    expect(result.statusCode).to.equal(200)
+    // The reply and the log say "sent", not "switched": the BMV does not ack.
+    expect(result.message).to.contain('sent')
+    expect(debugLogs.some((m) => m.includes('on command sent'))).to.be.true
+  })
+
+  it('accepts boolean true as relay-on', () => {
+    const { stubs, reg } = startSerial()
+    reg.handler('vessels.self', reg.path, true, () => {})
+    expect(stubs.calls.serialWrite[0]!.message).to.equal(':84E030001FB\n')
+  })
+
+  it('writes the relay-off command and reports success for value 0', () => {
+    const { stubs, reg } = startSerial()
+    const result = reg.handler(
+      'vessels.self',
+      reg.path,
+      0,
+      () => {}
+    ) as PutResult
+    expect(stubs.calls.serialWrite).to.deep.equal([
+      { message: ':84E030000FC\n', items: 0 }
+    ])
+    expect(result.state).to.equal('COMPLETED')
+    expect(result.statusCode).to.equal(200)
+    expect(result.message).to.contain('sent')
+  })
+
+  it('accepts boolean false as relay-off', () => {
+    const { stubs, reg } = startSerial()
+    reg.handler('vessels.self', reg.path, false, () => {})
+    expect(stubs.calls.serialWrite[0]!.message).to.equal(':84E030000FC\n')
+  })
+
+  it('rejects out-of-range, non-numeric and nullish values with 400, logs, and does not write', () => {
+    const { stubs, debugLogs, reg } = startSerial()
+    // Only 1/0/true/false are valid; everything else (negative, other numbers,
+    // numeric strings, null/undefined/NaN, objects) must be refused untouched.
+    const invalid: unknown[] = [-1, 2, '0', '1', null, undefined, NaN, {}]
+    for (const value of invalid) {
+      const result = reg.handler(
+        'vessels.self',
+        reg.path,
+        value,
+        () => {}
+      ) as PutResult
+      const label = `value ${JSON.stringify(value)}`
+      expect(result.state, label).to.equal('COMPLETED')
+      expect(result.statusCode, label).to.equal(400)
+      expect(result.message, label).to.contain('Invalid relay value')
+      // The offending path is echoed back so the caller sees which path failed.
+      expect(result.message, label).to.contain(reg.path)
+    }
+    expect(stubs.calls.serialWrite).to.have.lengthOf(0)
+    // Every rejection is logged, so a caller repeatedly sending bad values is
+    // diagnosable from the plugin log rather than silently ignored.
+    expect(debugLogs.filter((m) => m.includes('rejected'))).to.have.lengthOf(
+      invalid.length
+    )
+  })
+
+  it('reports failure when the serial port is not open', () => {
+    const { stubs, debugLogs, reg } = startSerial()
+    stubs.control.writeReturns = false // simulate a closed/absent port
+    const result = reg.handler(
+      'vessels.self',
+      reg.path,
+      1,
+      () => {}
+    ) as PutResult
+    expect(stubs.calls.serialWrite, 'write was attempted').to.have.lengthOf(1)
+    expect(result.state).to.equal('COMPLETED')
+    expect(result.statusCode).to.equal(503)
+    expect(result.message).to.contain('not open')
+    expect(debugLogs.some((m) => m.includes('not open'))).to.be.true
+  })
+
+  it('registers the relay handler for a legacy serial config', () => {
+    const { plugin, puts } = loadPlugin()
+    plugin.start({ device: '/dev/ttyUSB0' })
+    expect(puts).to.have.lengthOf(1)
+    expect(puts[0]!.path).to.equal('electrical.batteries.bmv.relay')
+  })
+
+  it('unregisters the relay handler on stop()', () => {
+    const { plugin, puts } = loadPlugin()
+    plugin.start({
+      vedirect: [conn({ device: 'Serial', connection: '/dev/ttyUSB0' })]
+    })
+    expect(puts[0]!.unregistered).to.be.false
+    plugin.stop()
+    expect(puts[0]!.unregistered).to.be.true
+  })
+
+  // Pins the per-connection index wiring: with the only serial+bmv connection at
+  // a non-zero index, the write must target that index (not a hardcoded 0) and
+  // stop() must unregister exactly that connection, leaving the non-serial slot
+  // (which registered nothing) untouched.
+  it('routes the write to the registering connection index and tears down only that one', () => {
+    const { plugin, stubs, puts } = loadPlugin()
+    plugin.start({
+      vedirect: [
+        conn({ device: 'UDP', port: 7878 }),
+        conn({ device: 'Serial', connection: '/dev/ttyUSB1', bmv: 'house' })
+      ]
+    })
+
+    expect(puts, 'only the serial connection registers').to.have.lengthOf(1)
+    expect(puts[0]!.path).to.equal('electrical.batteries.house.relay')
+
+    puts[0]!.handler('vessels.self', puts[0]!.path, 1, () => {})
+    expect(stubs.calls.serialWrite).to.deep.equal([
+      { message: ':84E030001FB\n', items: 1 }
+    ])
+
+    plugin.stop()
+    expect(puts[0]!.unregistered).to.be.true
   })
 })

--- a/test/unit/serial.ts
+++ b/test/unit/serial.ts
@@ -22,6 +22,11 @@ class FakeSerialPort {
   piped: FakeDelimiter | null = null
   closed = false
   closeThrows = false
+  // Mirrors SerialPort.isOpen; defaults to open since write() is only exercised
+  // after open(). A test flips it to false to model the reconnect gap.
+  isOpen = true
+  written: string[] = []
+  writeThrows = false
 
   constructor(public readonly opts: { path: string; baudRate: number }) {
     FakeSerialPort.instances.push(this)
@@ -33,6 +38,10 @@ class FakeSerialPort {
   pipe(delim: FakeDelimiter): FakeDelimiter {
     this.piped = delim
     return delim
+  }
+  write(data: string): void {
+    if (this.writeThrows) throw new Error('port dropped mid-write')
+    this.written.push(data)
   }
   close(): void {
     if (this.closeThrows) throw new Error('already gone')
@@ -176,6 +185,44 @@ describe('serial transport', () => {
 
       expect(FakeSerialPort.instances.length).to.equal(2)
       serial.close(() => {}, 0)
+    })
+  })
+
+  describe('write', () => {
+    it('writes a command to the open port and reports success', () => {
+      const serial = loadSerial()
+      serial.open('/dev/ttyUSB0', noParser, () => {}, 0)
+
+      const ok = serial.write(':84E030001FB\n', 0)
+
+      expect(ok).to.be.true
+      expect(FakeSerialPort.instances[0]!.written).to.deep.equal([
+        ':84E030001FB\n'
+      ])
+    })
+
+    it('reports failure when no port exists for the index', () => {
+      const serial = loadSerial()
+      expect(serial.write(':84E030001FB\n', 3)).to.be.false
+    })
+
+    it('reports failure (and does not write) when the port is not open', () => {
+      const serial = loadSerial()
+      serial.open('/dev/ttyUSB0', noParser, () => {}, 0)
+      FakeSerialPort.instances[0]!.isOpen = false // e.g. awaiting reconnect
+
+      const ok = serial.write(':84E030001FB\n', 0)
+
+      expect(ok).to.be.false
+      expect(FakeSerialPort.instances[0]!.written).to.have.lengthOf(0)
+    })
+
+    it('reports failure when the underlying write throws', () => {
+      const serial = loadSerial()
+      serial.open('/dev/ttyUSB0', noParser, () => {}, 0)
+      FakeSerialPort.instances[0]!.writeThrows = true
+
+      expect(serial.write(':84E030001FB\n', 0)).to.be.false
     })
   })
 })


### PR DESCRIPTION
Reimplements the idea from #64 (by @ardbiesheuvel) on the current TypeScript `src/*.ts` layout, and addresses the review feedback left on that PR.

The BMV-7xx built-in relay is exposed as a writable Signal K path, `electrical.batteries.<bmv>.relay`, for serial connections. A PUT sends the VE.Direct HEX "set" frame for register `0x034E` (`:84E030001FB` on / `:84E030000FC` off). The same path is already published by the existing `RELAY` field, so reads and writes line up.

Addressing the review on #64:

- **Silent failure / false 200** — `serial.write()` now returns success/failure (it checks the port is open). The handler replies `503` and logs when the port is not open, instead of a misleading `200`.
- **No unregister on stop** — the handler is torn down in `stop()` via the unregister callback returned by `registerPutHandler`, so a config reload leaves no stale handler writing to a closed port.
- **Boolean values** — the handler accepts `true`/`false` as well as `1`/`0`.
- **Tests** — added unit tests for a valid write, an invalid value, a missing/closed serial port, and the legacy config path (plus serial `write()` unit tests).
- **Merge conflicts** — based on latest `master`.

Relay control is serial-only (it requires writing back to the VE.Direct port) and needs the relay set to remote control on the BMV. The original PR's source-id commit is dropped, as it was superseded by #85.

Supersedes #64. @KEGustafsson @ardbiesheuvel