### PR TITLE
fix: use correct conversion to Joules from units of 0.01 kWh

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -20,9 +20,10 @@ const common = {
   },
 
   // value is in units of 0.01 kWh each
+  // 0.01 kWh == 10 * 3600 Ws == 36,000 J
   kWh(value: string | number): number | undefined {
     const n = common.number(value)
-    return n === undefined ? undefined : n / 100
+    return n === undefined ? undefined : n * 36000
   },
 
   mV(value: string | number): number | undefined {

--- a/test/integration/realCapture.ts
+++ b/test/integration/realCapture.ts
@@ -91,10 +91,10 @@ describe('integration: real BlueSolar MPPT 75/10 capture', () => {
     expect(valueAt('electrical.solar.Main.panelPower')).to.equal(42) // PPV 42 W
     expect(valueAt('electrical.solar.Main.load')).to.equal('off') // LOAD OFF
     expect(valueAt('electrical.solar.Main.loadCurrent')).to.equal(0) // IL 0 mA
-    expect(valueAt('electrical.solar.Main.yieldTotal')).to.equal(60.78) // H19 6078 (0.01 kWh)
-    expect(valueAt('electrical.solar.Main.yieldToday')).to.equal(0.14) // H20 14
+    expect(valueAt('electrical.solar.Main.yieldTotal')).to.equal(218808000) // H19 6078 (0.01 kWh)
+    expect(valueAt('electrical.solar.Main.yieldToday')).to.equal(504000) // H20 14
     expect(valueAt('electrical.solar.Main.maximumPowerToday')).to.equal(100) // H21
-    expect(valueAt('electrical.solar.Main.yieldYesterday')).to.equal(0.52) // H22 52
+    expect(valueAt('electrical.solar.Main.yieldYesterday')).to.equal(1872000) // H22 52
     expect(valueAt('electrical.solar.Main.maximumPowerYesterday')).to.equal(148) // H23
   })
 

--- a/test/unit/fields.ts
+++ b/test/unit/fields.ts
@@ -78,7 +78,7 @@ describe('fields - numeric converters', () => {
   })
 
   it('scales hundredths of a kWh to kWh (kWh)', () => {
-    expect(convert('H17', '6078')).to.equal(60.78)
+    expect(convert('H17', '6078')).to.equal(218808000)
     expect(convert('H17', 'x')).to.equal(undefined)
   })
 


### PR DESCRIPTION
The SignalK spec defines the Joule (J) as the unit of energy, not the kWh.

A Joule is the same as a Wattsecond, and so converting the values produced by the VE.Direct protocol, which reports energy in units of 10 Wh, involves multiplying by 10 * 3600 == 36000, not dividing by 100.

Fix this in the conversion, and fix up the testcases that were testing the wrong behavior.